### PR TITLE
Fix purchase lookup

### DIFF
--- a/lib/features/home/ui/tab/tabbar.dart
+++ b/lib/features/home/ui/tab/tabbar.dart
@@ -330,20 +330,24 @@ class TabbarState extends State<Tabbar> with WidgetsBindingObserver {
     }
   }
 
-  /// check if user has pruchased
-  PurchaseDetails _hasPurchased(String productId) {
+  /// check if user has purchased
+  PurchaseDetails? _hasPurchased(String productId) {
     debugPrint('======**************');
-    return purchases.firstWhere(
-      (purchase) => purchase.productID == productId,
-      // orElse: () => null
-    );
+    try {
+      return purchases.firstWhere(
+        (purchase) => purchase.productID == productId,
+      );
+    } catch (_) {
+      return null;
+    }
   }
 
   ///verifying pourchase of user
   Future<void> _verifyPuchase(String id) async {
-    PurchaseDetails purchase = _hasPurchased(id);
-    if (purchase.status == PurchaseStatus.purchased ||
-        purchase.status == PurchaseStatus.restored) {
+    PurchaseDetails? purchase = _hasPurchased(id);
+    if (purchase != null &&
+        (purchase.status == PurchaseStatus.purchased ||
+            purchase.status == PurchaseStatus.restored)) {
       debugPrint(purchase.productID);
       if (Platform.isIOS) {
         await iap.completePurchase(purchase);


### PR DESCRIPTION
## Summary
- prevent `StateError` if no purchase found by making _hasPurchased return nullable
- guard `_verifyPuchase` when purchase not found

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d6f5dfc4832581f913ec05c32c1a