### PR TITLE
Add basic tests and CI

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -1,0 +1,18 @@
+name: Flutter CI
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: flutter test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -86,6 +86,8 @@ dev_dependencies:
 
   flutter_test:
     sdk: flutter
+  bloc_test: ^10.0.0
+  mocktail: ^1.0.4
 
 flutter_icons:
   android: "launcher_icon"

--- a/test/auth/phone_auth_repository_test.dart
+++ b/test/auth/phone_auth_repository_test.dart
@@ -1,0 +1,33 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:naijasingles/common/data/repo/phone_auth_repo.dart';
+
+class MockFirebaseAuth extends Mock implements FirebaseAuth {}
+class MockUser extends Mock implements User {}
+
+void main() {
+  group('PhoneAuthRepository.isSignedIn', () {
+    test('returns true when there is a current user', () async {
+      final mockAuth = MockFirebaseAuth();
+      final repo = PhoneAuthRepository();
+      repo.auth = mockAuth;
+      when(() => mockAuth.currentUser).thenReturn(MockUser());
+
+      final result = await repo.isSignedIn();
+
+      expect(result, isTrue);
+    });
+
+    test('returns false when there is no current user', () async {
+      final mockAuth = MockFirebaseAuth();
+      final repo = PhoneAuthRepository();
+      repo.auth = mockAuth;
+      when(() => mockAuth.currentUser).thenReturn(null);
+
+      final result = await repo.isSignedIn();
+
+      expect(result, isFalse);
+    });
+  });
+}

--- a/test/payment/in_app_purchase_repo_test.dart
+++ b/test/payment/in_app_purchase_repo_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:in_app_purchase/in_app_purchase.dart';
+import 'package:naijasingles/common/data/repo/in_app_purchase_repo.dart';
+
+void main() {
+  group('InAppPurchaseRepoImpl.hasPurchased', () {
+    test('returns the matching purchase', () {
+      final purchase1 = PurchaseDetails(
+        productID: 'id1',
+        purchaseID: '1',
+        verificationData: const PurchaseVerificationData(
+          localVerificationData: 'local',
+          serverVerificationData: 'server',
+          source: 'test',
+        ),
+        transactionDate: '0',
+        status: PurchaseStatus.purchased,
+      );
+      final purchase2 = PurchaseDetails(
+        productID: 'id2',
+        purchaseID: '2',
+        verificationData: const PurchaseVerificationData(
+          localVerificationData: 'local',
+          serverVerificationData: 'server',
+          source: 'test',
+        ),
+        transactionDate: '0',
+        status: PurchaseStatus.purchased,
+      );
+
+      final result = InAppPurchaseRepoImpl.hasPurchased('id2', [purchase1, purchase2]);
+
+      expect(result.productID, 'id2');
+    });
+  });
+}

--- a/test/user/user_repo_test.dart
+++ b/test/user/user_repo_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naijasingles/common/data/repo/user_repo.dart';
+import 'package:naijasingles/models/user_model.dart';
+
+void main() {
+  group('UserRepo.chatId1', () {
+    test('orders ids alphabetically when hashCode is lower', () {
+      final currentUser = UserModel(id: 'a');
+      final chatId = UserRepo.chatId1(currentUser, 'b');
+      expect(chatId, 'a-b');
+    });
+
+    test('orders ids alphabetically when hashCode is higher', () {
+      final currentUser = UserModel(id: 'b');
+      final chatId = UserRepo.chatId1(currentUser, 'a');
+      expect(chatId, 'a-b');
+    });
+  });
+}

--- a/test/widgets/login_option_page_test.dart
+++ b/test/widgets/login_option_page_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:provider/provider.dart';
+import 'package:naijasingles/features/auth/phone/ui/screens/login_option_page.dart';
+import 'package:naijasingles/features/auth/facebook_login/facebook_login_bloc.dart';
+import 'package:naijasingles/features/auth/auth_status/bloc/registration/bloc/registration_bloc.dart';
+import 'package:naijasingles/common/providers/theme_provider.dart';
+import 'package:naijasingles/common/providers/user_provider.dart';
+import 'package:naijasingles/common/data/repo/phone_auth_repo.dart';
+
+void main() {
+  testWidgets('shows phone number login button', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider(create: (_) => ThemeProvider()),
+          ChangeNotifierProvider(create: (_) => UserProvider()),
+        ],
+        child: MultiBlocProvider(
+          providers: [
+            BlocProvider(create: (_) => FacebookLoginBloc()),
+            BlocProvider(
+              create: (_) => RegistrationBloc(
+                phoneAuthRepository: PhoneAuthRepository(),
+              ),
+            ),
+          ],
+          child: const MaterialApp(
+            home: LoginOption(),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('LOG IN WITH PHONE NUMBER'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add bloc_test and mocktail for testing
- add phone auth repository tests
- add user repo tests for chat ID logic
- add purchase repo unit tests
- add widget test for login option page
- integrate flutter tests in GitHub Actions CI workflow

## Testing
- `./flutter/bin/flutter --version` *(fails: Failed to retrieve the Dart SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6846dee14c808325aabf74c466930a72