### PR TITLE
Update intl version

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -873,10 +873,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: 3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.18.1"
   iris_method_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,7 +62,7 @@ dependencies:
   in_app_purchase: ^3.1.13       # Kept at 3.1.13
   in_app_purchase_storekit: ^0.3.13+1 # Kept at 0.3.13+1
   in_app_purchase_android: ^0.3.2 # Kept at 0.3.2
-  intl: any                      # Kept as `any`
+  intl: ^0.18.0                  # Specify intl version
   location: ^7.0.0               # Upgraded from 6.0.1
   rflutter_alert: ^2.0.7         # Kept at 2.0.7
   otp_autofill: ^3.0.2           # Kept at 3.0.2


### PR DESCRIPTION
## Summary
- pin `intl` dependency to `^0.18.0`
- lockfile updated for `intl 0.18.1`

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846def140f8832589cc6c227c7ede9d