### PR TITLE
Remove old bloc_test entry

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -83,8 +83,6 @@ dev_dependencies:
   flutter_lints: ^2.0.3           # Upgraded from 2.0.3
   device_preview: ^1.2.0            # Upgraded from 1.1.0
   flutter_native_splash: ^2.4.1     # Upgraded from 2.2.19
-  bloc_test: ^9.1.7
-
   flutter_test:
     sdk: flutter
   bloc_test: ^10.0.0


### PR DESCRIPTION
## Summary
- remove the outdated `bloc_test: ^9.1.7` dev dependency

## Testing
- `flutter pub get` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684877bf3860832581af42433718186d