### PR TITLE
Replace deprecated Flutter Google Places plugin

### DIFF
--- a/lib/features/user/ui/screens/update_user_location.dart
+++ b/lib/features/user/ui/screens/update_user_location.dart
@@ -2,7 +2,7 @@
 
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_google_places/flutter_google_places.dart';
+import 'package:flutter_google_places_hoc081098/flutter_google_places_hoc081098.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:google_maps_webservice/places.dart';
 import 'package:naijasingles/common/constants/colors.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -566,14 +566,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.0.2"
-  flutter_google_places:
+  flutter_google_places_hoc081098:
     dependency: "direct main"
     description:
-      name: flutter_google_places
-      sha256: e9fb23ceacdc7359aa759627550146f7fd3ae6c067d16f39f3c50d8feebf4809
+      name: flutter_google_places_hoc081098
+      sha256: 75492cf112eac0d6dc08181e2601d7c6ea867cc05077c6c1604b5d527e0f92c7
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "2.0.0"
   flutter_image_compress:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,7 +49,7 @@ dependencies:
   flutter_facebook_auth: ^7.1.2  # Updated to latest version
   google_api_headers: ^4.5.2     # Explicitly depend on latest headers
   flutter_flushbar: ^0.0.2       # Kept at 0.0.2
-  flutter_google_places: 0.3.0   # Kept at 0.3.0
+  flutter_google_places_hoc081098: ^2.0.0
   flutter_image_compress: ^2.3.0 # Upgraded from 2.2.0
   flutter_swiper_null_safety: ^1.0.2 # Kept at 1.0.2
   fluttertoast: ^8.2.1           # Upgraded from 8.2.1


### PR DESCRIPTION
## Summary
- switch to `flutter_google_places_hoc081098`
- update import for new plugin
- update lock file for `flutter_google_places_hoc081098`

## Testing
- `flutter pub get` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68488a7d1e888325a4a2b4f41308a8db