### PR TITLE
Clean up location bloc events

### DIFF
--- a/lib/services/location/bloc/userlocation_event.dart
+++ b/lib/services/location/bloc/userlocation_event.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: annotate_overrides
-
 part of 'userlocation_bloc.dart';
 
 abstract class UserLocationEvents extends Equatable {
@@ -11,12 +9,6 @@ abstract class UserLocationEvents extends Equatable {
 
 class UserLocationRequest extends UserLocationEvents {
   const UserLocationRequest();
-
-  List<Object> get props => [];
-}
-
-abstract class UserlocationEvent extends Equatable {
-  const UserlocationEvent();
 
   @override
   List<Object> get props => [];


### PR DESCRIPTION
## Summary
- remove leftover `UserlocationEvent` class
- add proper override annotation for `UserLocationRequest`

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488cfa13d08325a8a66bb551d79962