### PR TITLE
Replace print with debugPrint

### DIFF
--- a/lib/features/home/ui/tab/tabbar.dart
+++ b/lib/features/home/ui/tab/tabbar.dart
@@ -445,7 +445,7 @@ class TabbarState extends State<Tabbar> with WidgetsBindingObserver {
     try {
       FlutterCallkitIncoming.onEvent.listen((event) async {
         if (kDebugMode) {
-          print('HOME: $event');
+          debugPrint('HOME: $event');
         }
         switch (event!.event) {
           case Event.actionCallIncoming:


### PR DESCRIPTION
## Summary
- replace a stray `print` call with `debugPrint`

## Testing
- `flutter --version` *(fails: command not found)*
- `sudo apt-get install -y flutter` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a21a67bf08325a22a6caca2b6217c