### PR TITLE
Remove print usage in tabbar.dart

### DIFF
--- a/lib/features/home/ui/tab/tabbar.dart
+++ b/lib/features/home/ui/tab/tabbar.dart
@@ -445,7 +445,7 @@ class TabbarState extends State<Tabbar> with WidgetsBindingObserver {
     try {
       FlutterCallkitIncoming.onEvent.listen((event) async {
         if (kDebugMode) {
-          print('HOME: $event');
+          debugPrint('HOME: $event');
         }
         switch (event!.event) {
           case Event.actionCallIncoming:


### PR DESCRIPTION
## Summary
- refactor tabbar to use `debugPrint` instead of `print`

## Testing
- `grep -n \bprint( lib/features/home/ui/tab/tabbar.dart`


------
https://chatgpt.com/codex/tasks/task_e_684a22d0bff483259921f58430a32842