### PR TITLE
Align google places deps with older API

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -570,10 +570,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_google_places_hoc081098
-      sha256: 75492cf112eac0d6dc08181e2601d7c6ea867cc05077c6c1604b5d527e0f92c7
+      sha256: b416afe9004d61b643d2c6467e6401960fe3102835a5df846683f47875183b0b
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "1.2.0"
   flutter_image_compress:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,9 +47,9 @@ dependencies:
   flutter_bloc: ^9.1.1           # Upgraded from 8.1.6
   flutter_callkit_incoming: ^2.0.0 # Kept at 2.0.0
   flutter_facebook_auth: ^7.1.2  # Updated to latest version
-  google_api_headers: ^4.5.2     # Explicitly depend on latest headers
+  google_api_headers: ^1.6.0     # Explicitly depend on compatible headers
   flutter_flushbar: ^0.0.2       # Kept at 0.0.2
-  flutter_google_places_hoc081098: ^2.0.0
+  flutter_google_places_hoc081098: ^1.2.0
   flutter_image_compress: ^2.3.0 # Upgraded from 2.2.0
   flutter_swiper_null_safety: ^1.0.2 # Kept at 1.0.2
   fluttertoast: ^8.2.1           # Upgraded from 8.2.1


### PR DESCRIPTION
## Summary
- downgrade `flutter_google_places_hoc081098` to 1.2.0
- switch `google_api_headers` to 1.6.0
- keep `http` at 0.13.6
- ensure user location screen imports `google_maps_webservice`

## Testing
- `flutter pub get` *(fails: `flutter: command not found`)*
- `flutter build ios --no-codesign` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a1ccfe3188325aeeb8cd3bde42385