### PR TITLE
Refactor getLikedByList

### DIFF
--- a/lib/common/data/repo/user_search_repo.dart
+++ b/lib/common/data/repo/user_search_repo.dart
@@ -15,7 +15,7 @@ class UserSearchRepo {
   static Map items = {};
   static List<UserModel> matches = [];
   static List<UserModel> newmatches = [];
-  static List<dynamic> likedByList = [];
+  static List<String> likedByList = [];
   static List userRemoved = [];
   static int swipecount = 0;
   static List<UserModel> users = [];
@@ -61,7 +61,7 @@ class UserSearchRepo {
   }
 
   static rightSwipe(UserModel currentUser, UserModel selectedUser) async {
-    likedByList = getLikedByList(currentUser);
+    likedByList = await getLikedByList(currentUser);
     if ((likedByList.contains(selectedUser.id) ||
         (selectedUser.isBot ?? false))) {
       debugPrint("coming umder searchrepo in if rightswipe");
@@ -188,15 +188,15 @@ class UserSearchRepo {
     return userList;
   }
 
-  static List<dynamic> getLikedByList(UserModel currentUser) {
-    docRef
+  static Future<List<String>> getLikedByList(UserModel currentUser) async {
+    final snapshot = await docRef
         .doc(currentUser.id)
         .collection("LikedBy")
-        .snapshots()
-        .listen((data) async {
-      likedByList.addAll(data.docs.map((f) => f['LikedBy']));
-    });
-    return likedByList;
+        .get();
+
+    return snapshot.docs
+        .map((f) => f['LikedBy'] as String)
+        .toList();
   }
 
   static double calculateDistance(lat1, lon1, lat2, lon2) {

--- a/lib/features/home/ui/screens/home_page.dart
+++ b/lib/features/home/ui/screens/home_page.dart
@@ -44,7 +44,7 @@ class HomepageState extends State<Homepage>
   SwipableStackController? stackController;
   // List<UserModel> users = [];
   int swipedcount = 0;
-  List likedByList = [];
+  List<String> likedByList = [];
 
   late final UserModel currentUser;
   InterstitialAd? interstitialAd;
@@ -64,8 +64,13 @@ class HomepageState extends State<Homepage>
   void initState() {
     final userProvider = Provider.of<UserProvider>(context, listen: false);
     currentUser = userProvider.currentUser!;
-    likedByList = UserSearchRepo.getLikedByList(currentUser);
-    log("unmatch list is $likedByList");
+    UserSearchRepo.getLikedByList(currentUser).then((list) {
+      setState(() {
+        likedByList = list;
+      });
+      log("unmatch list is $likedByList");
+      log("likedbylist$likedByList");
+    });
 
     fetchData();
     context.read<SearchUserBloc>().add(LoadUserEvent(


### PR DESCRIPTION
## Summary
- make `getLikedByList` async and return `Future<List<String>>`
- await likedBy list in `rightSwipe`
- load liked by list asynchronously on HomePage
- type likedBy lists as `List<String>`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a2ae144a88325bbf536542a326ca2