### PR TITLE
Fix chatId ordering with compareTo

### DIFF
--- a/lib/common/data/repo/user_repo.dart
+++ b/lib/common/data/repo/user_repo.dart
@@ -75,10 +75,11 @@ class UserRepo {
   }
 
   static String chatId1(UserModel currentUser, String userId) {
-    if (currentUser.id.hashCode <= userId.hashCode) {
-      return '${currentUser.id}-$userId';
+    final currentId = currentUser.id ?? '';
+    if (currentId.compareTo(userId) <= 0) {
+      return '$currentId-$userId';
     } else {
-      return '$userId-${currentUser.id}';
+      return '$userId-$currentId';
     }
   }
 

--- a/test/user/user_repo_test.dart
+++ b/test/user/user_repo_test.dart
@@ -4,13 +4,13 @@ import 'package:naijasingles/models/user_model.dart';
 
 void main() {
   group('UserRepo.chatId1', () {
-    test('orders ids alphabetically when hashCode is lower', () {
+    test('returns ids in ascending order when current id precedes other', () {
       final currentUser = UserModel(id: 'a');
       final chatId = UserRepo.chatId1(currentUser, 'b');
       expect(chatId, 'a-b');
     });
 
-    test('orders ids alphabetically when hashCode is higher', () {
+    test('returns ids in ascending order when current id follows other', () {
       final currentUser = UserModel(id: 'b');
       final chatId = UserRepo.chatId1(currentUser, 'a');
       expect(chatId, 'a-b');


### PR DESCRIPTION
## Summary
- use `compareTo` for ordering chat IDs
- update tests to clarify alphabetical ordering

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a2ac4415483259cadeb30c467107a