### PR TITLE
Handle null image selection

### DIFF
--- a/lib/features/chat/ui/widgets/send_message_box.dart
+++ b/lib/features/chat/ui/widgets/send_message_box.dart
@@ -18,6 +18,8 @@ import '../../../../models/user_model.dart';
 import 'chatmessage_read.dart.dart';
 import 'generate_layout.dart';
 
+bool shouldUploadImage(XFile? image) => image != null;
+
 class MessageBox extends StatefulWidget {
   final UserModel sender;
   final String chatId;
@@ -254,14 +256,16 @@ class _MessageBoxState extends State<MessageBox> {
                     onPressed: () async {
                       ImagePicker imagePicker = ImagePicker();
 
-                      var image = await imagePicker.pickImage(
+                      final image = await imagePicker.pickImage(
                           source: ImageSource.gallery);
+                      if (!shouldUploadImage(image)) return;
+
                       int timestamp = DateTime.now().millisecondsSinceEpoch;
                       Reference storageReference = FirebaseStorage.instance
                           .ref()
                           .child('chats/${widget.chatId}/img_$timestamp.jpg');
                       UploadTask uploadTask =
-                          storageReference.putFile(File(image!.path));
+                          storageReference.putFile(File(image.path));
                       CustomToast.showToast('sending...'.tr().toString());
                       await uploadTask.then((p0) async {
                         String fileUrl =

--- a/test/chat/should_upload_image_test.dart
+++ b/test/chat/should_upload_image_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:naijasingles/features/chat/ui/widgets/send_message_box.dart';
+
+void main() {
+  group('shouldUploadImage', () {
+    test('returns false when image is null', () {
+      final result = shouldUploadImage(null);
+      expect(result, isFalse);
+    });
+
+    test('returns true when image is provided', () {
+      final image = XFile('path');
+      final result = shouldUploadImage(image);
+      expect(result, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- ensure that MessageBox checks if user selected an image before uploading
- expose `shouldUploadImage` helper with tests

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a2d6faf7c8325a8ef120d09b067ca