### PR TITLE
Update http package version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,7 +73,7 @@ dependencies:
   swipable_stack: ^2.0.0         # Kept at 2.0.0
   uuid: ^4.5.1                   # Updated to latest
   webview_flutter: ^4.13.0       # Updated to latest
-  http: ^1.4.0
+  http: ^0.13.6
   google_maps_webservice: ^0.0.20-nullsafety.5
   google_fonts: ^6.2.1
   flutter_google_places_hoc081098: ^2.0.0


### PR DESCRIPTION
## Summary
- downgrade `http` package to 0.13.x

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684a35f1c0388325bdea064c496b4837