### PR TITLE
Remove rethrows in bloc handlers

### DIFF
--- a/lib/features/blockUser/bloc/bloc_user_list_bloc.dart
+++ b/lib/features/blockUser/bloc/bloc_user_list_bloc.dart
@@ -24,7 +24,7 @@ class BlocUserListBloc extends Bloc<BlocUserListEvent, BlocUserListState> {
         emit(BlockUserLoadedState(blockList));
       } catch (e) {
         emit(BlockUserFailedState());
-        rethrow;
+        log('Error loading block users: $e');
       }
     });
 
@@ -50,7 +50,7 @@ class BlocUserListBloc extends Bloc<BlocUserListEvent, BlocUserListState> {
         }
       } catch (e) {
         emit(BlockUserFailedState());
-        rethrow;
+        log('Error loading more block users: $e');
       }
     });
   }

--- a/lib/features/explore/bloc/explore_map_bloc.dart
+++ b/lib/features/explore/bloc/explore_map_bloc.dart
@@ -21,7 +21,7 @@ class SearchUserForMapBloc
         emit(SearchUserLoadUserForMapState(userList));
       } catch (e) {
         emit(SearchUserFailedForMapState());
-        rethrow;
+        log('Error loading map users: $e');
       }
     });
   }

--- a/lib/features/home/bloc/searchuser_bloc.dart
+++ b/lib/features/home/bloc/searchuser_bloc.dart
@@ -20,7 +20,7 @@ class SearchUserBloc extends Bloc<SearchUserEvent, SearchUserState> {
         emit(SearchUserLoadUserState(userList));
       } catch (e) {
         emit(SearchUserFailedState());
-        rethrow;
+        log('Error loading users: $e');
       }
     });
   }

--- a/lib/features/home/bloc/swipebloc_bloc.dart
+++ b/lib/features/home/bloc/swipebloc_bloc.dart
@@ -23,7 +23,7 @@ class SwipeBloc extends Bloc<SwipeblocEvent, SwipeblocState> {
         log("cominguser from leftevent");
       } catch (e) {
         emit(SwipeFailedState());
-        rethrow;
+        log('Error while processing left swipe: $e');
       }
     });
     on<RightSwipeEvent>((event, emit) async {
@@ -38,7 +38,7 @@ class SwipeBloc extends Bloc<SwipeblocEvent, SwipeblocState> {
         log("cominguser from rightevent");
       } catch (e) {
         emit(SwipeFailedState());
-        rethrow;
+        log('Error while processing right swipe: $e');
       }
     });
   }

--- a/lib/features/home/ui/screens/user_filter/bloc/userfilter_bloc.dart
+++ b/lib/features/home/ui/screens/user_filter/bloc/userfilter_bloc.dart
@@ -21,7 +21,8 @@ class UserfilterBloc extends Bloc<UserfilterEvent, UserfilterState> {
       } on SocketException {
         emit(const UserFilterUpdationFailed(message: 'No Internet Connection'));
       } catch (e) {
-        rethrow;
+        emit(UserFilterUpdationFailed(message: e.toString()));
+        log('Error updating filter: $e');
       }
     });
   }

--- a/lib/features/match/bloc/match_bloc.dart
+++ b/lib/features/match/bloc/match_bloc.dart
@@ -21,7 +21,7 @@ class MatchUserBloc extends Bloc<MatchUserEvent, MatchUserState> {
         emit(MatchUserLoadedState(matchList));
       } catch (e) {
         emit(MatchUserFailedState());
-        rethrow;
+        log('Error loading matches: $e');
       }
     });
   }

--- a/lib/features/report/bloc/report_bloc.dart
+++ b/lib/features/report/bloc/report_bloc.dart
@@ -17,7 +17,7 @@ class ReportBloc extends Bloc<ReportEvents, ReportStates> {
         emit(const ReportUserSuccess(message: "User Reported"));
       } catch (e) {
         emit(ReportUserFailed(message: e.toString()));
-        rethrow;
+        log('Error reporting user: $e');
       }
     });
   }

--- a/lib/features/street_view/bloc/streetviewdata_bloc.dart
+++ b/lib/features/street_view/bloc/streetviewdata_bloc.dart
@@ -27,7 +27,7 @@ class StreetviewdataBloc
         emit(StreetViewDataLoadedState(stringUserIds, option));
       } catch (e) {
         emit(StreetViewDataFailedState());
-        rethrow;
+        log('Error loading street view data: $e');
       }
     });
   }

--- a/lib/features/user/bloc/update_user_bloc.dart
+++ b/lib/features/user/bloc/update_user_bloc.dart
@@ -17,7 +17,8 @@ class UserBloc extends Bloc<UserEvents, UserStates> {
       } on SocketException {
         emit(const UserUpdationFailed(message: 'No Internet Connection'));
       } catch (e) {
-        rethrow;
+        emit(UserUpdationFailed(message: e.toString()));
+        log('Error updating user: $e');
       }
     });
     on<UpdateUserProfilePictures>((event, emit) async {


### PR DESCRIPTION
## Summary
- update bloc handlers to log failures instead of rethrowing

## Testing
- `grep -nR "rethrow" lib/**/bloc/**/*.dart`

------
https://chatgpt.com/codex/tasks/task_e_684b2416397883258dec8ada9252a7b2