### PR TITLE
Add bloc and repository tests

### DIFF
--- a/lib/common/constants/constants.dart
+++ b/lib/common/constants/constants.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:naijasingles/config/app_config.dart';
 
-final firebaseFireStoreInstance = FirebaseFirestore.instance;
-final firebaseAuthInstance = FirebaseAuth.instance;
-final firebaseStorageInstance = FirebaseStorage.instanceFor(bucket: bucketId);
+FirebaseFirestore firebaseFireStoreInstance = FirebaseFirestore.instance;
+FirebaseAuth firebaseAuthInstance = FirebaseAuth.instance;
+FirebaseStorage firebaseStorageInstance =
+    FirebaseStorage.instanceFor(bucket: bucketId);

--- a/lib/common/data/repo/user_messaging_repo.dart
+++ b/lib/common/data/repo/user_messaging_repo.dart
@@ -11,8 +11,8 @@ import '../../../models/user_model.dart';
 import '../../constants/constants.dart';
 
 class UserMessagingRepo {
-  static final db = firebaseFireStoreInstance;
-  static CollectionReference docRef = db.collection('Users');
+  static FirebaseFirestore db = firebaseFireStoreInstance;
+  static CollectionReference get docRef => db.collection('Users');
 
   static FirebaseAuth firebaseAuth = firebaseAuthInstance;
 

--- a/lib/common/data/repo/user_search_repo.dart
+++ b/lib/common/data/repo/user_search_repo.dart
@@ -8,8 +8,8 @@ import 'package:naijasingles/models/user_model.dart';
 import '../../constants/constants.dart';
 
 class UserSearchRepo {
-  static CollectionReference docRef =
-      firebaseFireStoreInstance.collection('Users');
+  static FirebaseFirestore db = firebaseFireStoreInstance;
+  static CollectionReference get docRef => db.collection('Users');
 
   static FirebaseAuth firebaseAuth = firebaseAuthInstance;
   static Map items = {};
@@ -22,7 +22,7 @@ class UserSearchRepo {
   static Map likedMap = {};
   static Map disLikedMap = {};
   static getAccessItems() async {
-    firebaseFireStoreInstance
+    db
         .collection("Item_access")
         .snapshots()
         .listen((doc) {
@@ -34,7 +34,7 @@ class UserSearchRepo {
   }
 
   static Future<int> getSwipedCount(UserModel currentUser) async {
-    final querySnapshot = await firebaseFireStoreInstance
+    final querySnapshot = await db
         .collection('/Users/${currentUser.id}/CheckedUser')
         .where(
           'timestamp',
@@ -138,7 +138,7 @@ class UserSearchRepo {
   ) async {
     List<String> checkedUserIds = [];
 
-    final snapshot = await firebaseFireStoreInstance
+    final snapshot = await db
         .collection('/Users/${currentUser.id}/CheckedUser')
         .get();
     if (snapshot.docs.isNotEmpty) {

--- a/lib/features/home/bloc/swipebloc_bloc.dart
+++ b/lib/features/home/bloc/swipebloc_bloc.dart
@@ -10,13 +10,24 @@ part 'swipebloc_event.dart';
 part 'swipebloc_state.dart';
 
 class SwipeBloc extends Bloc<SwipeblocEvent, SwipeblocState> {
-  SwipeBloc() : super(SwipeblocInitial()) {
+  final Future<void> Function(UserModel, UserModel) leftSwipe;
+  final Future<void> Function(UserModel, UserModel) rightSwipe;
+  final Future<List<UserModel>> Function(UserModel) getUserList;
+
+  SwipeBloc({
+    Future<void> Function(UserModel, UserModel)? leftSwipe,
+    Future<void> Function(UserModel, UserModel)? rightSwipe,
+    Future<List<UserModel>> Function(UserModel)? getUserList,
+  })  : leftSwipe = leftSwipe ?? UserSearchRepo.leftSwipe,
+        rightSwipe = rightSwipe ?? UserSearchRepo.rightSwipe,
+        getUserList = getUserList ?? UserSearchRepo.getUserList,
+        super(SwipeblocInitial()) {
     on<LeftSwipeEvent>((event, emit) async {
       // emit(SearchUserLoadingState());
       try {
-        UserSearchRepo.leftSwipe(event.currentUser, event.selectedUser);
+        await this.leftSwipe(event.currentUser, event.selectedUser);
         List<UserModel> userList =
-            await UserSearchRepo.getUserList(event.currentUser);
+            await this.getUserList(event.currentUser);
         emit(SwipeSucessState(userList));
 
         log("afterlefteventuser${userList.toString()}");
@@ -29,9 +40,9 @@ class SwipeBloc extends Bloc<SwipeblocEvent, SwipeblocState> {
     on<RightSwipeEvent>((event, emit) async {
       // emit(SearchUserLoadingState());
       try {
-        UserSearchRepo.rightSwipe(event.currentUser, event.selectedUser);
+        await this.rightSwipe(event.currentUser, event.selectedUser);
         List<UserModel> userList =
-            await UserSearchRepo.getUserList(event.currentUser);
+            await this.getUserList(event.currentUser);
 
         emit(SwipeSucessState(userList));
         log("afterrighteventuser${userList.toString()}");

--- a/lib/features/match/bloc/match_bloc.dart
+++ b/lib/features/match/bloc/match_bloc.dart
@@ -10,12 +10,16 @@ part 'match_event.dart';
 part 'match_state.dart';
 
 class MatchUserBloc extends Bloc<MatchUserEvent, MatchUserState> {
-  MatchUserBloc() : super(MatchUserInitial()) {
+  final Future<List<UserModel>> Function(UserModel currentUser) getMatches;
+
+  MatchUserBloc({
+    Future<List<UserModel>> Function(UserModel currentUser)? getMatches,
+  })  : getMatches = getMatches ?? UserMessagingRepo.getMatches,
+        super(MatchUserInitial()) {
     on<LoadMatchUserEvent>((event, emit) async {
       emit(MatchUserLoadingState());
       try {
-        List<UserModel> matchList =
-            await UserMessagingRepo.getMatches(event.currentUser);
+        final matchList = await this.getMatches(event.currentUser);
         log("matchuser${matchList.toString()}");
         log("matchuser from matchbloc");
         emit(MatchUserLoadedState(matchList));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,6 +87,8 @@ dev_dependencies:
     sdk: flutter
   bloc_test: ^10.0.0
   mocktail: ^1.0.4
+  fake_cloud_firestore: ^2.4.1
+  firebase_auth_mocks: ^0.13.0
 
 flutter_icons:
   android: "launcher_icon"

--- a/test/auth/registration_bloc_test.dart
+++ b/test/auth/registration_bloc_test.dart
@@ -1,0 +1,71 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:naijasingles/features/auth/auth_status/bloc/registration/bloc/registration_bloc.dart';
+import 'package:naijasingles/common/data/repo/phone_auth_repo.dart';
+import 'package:naijasingles/models/user_model.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+class MockPhoneAuthRepository extends Mock implements PhoneAuthRepository {}
+class MockFirebaseUser extends Mock implements User {}
+
+void main() {
+  group('RegistrationBloc', () {
+    late MockPhoneAuthRepository repo;
+    late RegistrationBloc bloc;
+
+    setUp(() {
+      repo = MockPhoneAuthRepository();
+      bloc = RegistrationBloc(phoneAuthRepository: repo);
+    });
+
+    final userModel = UserModel(id: '1', name: 'test');
+    final firebaseUser = MockFirebaseUser();
+
+    blocTest<RegistrationBloc, RegistrationStates>(
+      'emits [Loading, Success] on RegistrationRequest',
+      build: () {
+        when(() => repo.getCurrentUser()).thenAnswer((_) async => firebaseUser);
+        when(() => repo.registration(userData: any(named: 'userData')))
+            .thenAnswer((_) async => userModel);
+        return bloc;
+      },
+      act: (bloc) => bloc.add(const RegistrationRequest(userdata: {})),
+      expect: () => [
+        RegistrationLoading(),
+        RegistrationSuccess(user: userModel),
+      ],
+    );
+
+    blocTest<RegistrationBloc, RegistrationStates>(
+      'emits [Loading, AlreadyRegistered] when user already registered',
+      build: () {
+        when(() => repo.getCurrentUser()).thenAnswer((_) async => firebaseUser);
+        when(() => firebaseUser.displayName).thenReturn('name');
+        when(() => repo.userDetails(any())).thenAnswer((_) async => true);
+        when(() => repo.getRegisterUser()).thenAnswer((_) async => userModel);
+        return bloc;
+      },
+      act: (bloc) => bloc.add(const CheckRegistration(token: 't')),
+      expect: () => [
+        RegistrationLoading(),
+        AlreadyRegistered(user: userModel),
+      ],
+    );
+
+    blocTest<RegistrationBloc, RegistrationStates>(
+      'emits [Loading, NewRegistration] when no data found',
+      build: () {
+        when(() => repo.getCurrentUser()).thenAnswer((_) async => firebaseUser);
+        when(() => firebaseUser.displayName).thenReturn('name');
+        when(() => repo.userDetails(any())).thenAnswer((_) async => false);
+        return bloc;
+      },
+      act: (bloc) => bloc.add(const CheckRegistration(token: 't')),
+      expect: () => [
+        RegistrationLoading(),
+        NewRegistration(token: 't', user: firebaseUser),
+      ],
+    );
+  });
+}

--- a/test/home/swipe_bloc_test.dart
+++ b/test/home/swipe_bloc_test.dart
@@ -1,0 +1,45 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naijasingles/features/home/bloc/swipebloc_bloc.dart';
+import 'package:naijasingles/models/user_model.dart';
+
+void main() {
+  group('SwipeBloc', () {
+    final currentUser = UserModel(id: '1');
+    final selectedUser = UserModel(id: '2');
+    final list = [UserModel(id: '3')];
+
+    blocTest<SwipeBloc, SwipeblocState>(
+      'emits success after right swipe',
+      build: () => SwipeBloc(
+        rightSwipe: (_, __) async {},
+        getUserList: (_) async => list,
+        leftSwipe: (_, __) async {},
+      ),
+      act: (bloc) => bloc.add(RightSwipeEvent(currentUser: currentUser, selectedUser: selectedUser)),
+      expect: () => [SwipeSucessState(list)],
+    );
+
+    blocTest<SwipeBloc, SwipeblocState>(
+      'emits success after left swipe',
+      build: () => SwipeBloc(
+        leftSwipe: (_, __) async {},
+        getUserList: (_) async => list,
+        rightSwipe: (_, __) async {},
+      ),
+      act: (bloc) => bloc.add(LeftSwipeEvent(currentUser: currentUser, selectedUser: selectedUser)),
+      expect: () => [SwipeSucessState(list)],
+    );
+
+    blocTest<SwipeBloc, SwipeblocState>(
+      'emits failed state on exception',
+      build: () => SwipeBloc(
+        rightSwipe: (_, __) => throw Exception(),
+        getUserList: (_) async => [],
+        leftSwipe: (_, __) async {},
+      ),
+      act: (bloc) => bloc.add(RightSwipeEvent(currentUser: currentUser, selectedUser: selectedUser)),
+      expect: () => [SwipeFailedState()],
+    );
+  });
+}

--- a/test/home/user_search_repo_test.dart
+++ b/test/home/user_search_repo_test.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naijasingles/common/data/repo/user_search_repo.dart';
+
+void main() {
+  test('calculateDistance returns expected value', () {
+    final distance = UserSearchRepo.calculateDistance(0, 0, 0, 1);
+    // Distance between (0,0) and (0,1) is about 111 km
+    expect(distance, closeTo(111, 1));
+  });
+}

--- a/test/match/match_bloc_test.dart
+++ b/test/match/match_bloc_test.dart
@@ -1,0 +1,35 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naijasingles/features/match/bloc/match_bloc.dart';
+import 'package:naijasingles/models/user_model.dart';
+
+void main() {
+  group('MatchUserBloc', () {
+    final currentUser = UserModel(id: '1');
+    final otherUser = UserModel(id: '2');
+
+    blocTest<MatchUserBloc, MatchUserState>(
+      'emits [Loading, Loaded] when repository returns data',
+      build: () => MatchUserBloc(
+        getMatches: (_) async => [otherUser],
+      ),
+      act: (bloc) => bloc.add(LoadMatchUserEvent(currentUser: currentUser)),
+      expect: () => [
+        MatchUserLoadingState(),
+        MatchUserLoadedState([otherUser]),
+      ],
+    );
+
+    blocTest<MatchUserBloc, MatchUserState>(
+      'emits [Loading, Failed] on error',
+      build: () => MatchUserBloc(
+        getMatches: (_) => throw Exception('error'),
+      ),
+      act: (bloc) => bloc.add(LoadMatchUserEvent(currentUser: currentUser)),
+      expect: () => [
+        MatchUserLoadingState(),
+        MatchUserFailedState(),
+      ],
+    );
+  });
+}

--- a/test/match/user_messaging_repo_test.dart
+++ b/test/match/user_messaging_repo_test.dart
@@ -1,0 +1,26 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naijasingles/common/constants/constants.dart';
+import 'package:naijasingles/common/data/repo/user_messaging_repo.dart';
+import 'package:naijasingles/models/user_model.dart';
+
+void main() {
+  test('getChatUserDetails returns user data', () async {
+    firebaseFireStoreInstance = FakeFirebaseFirestore();
+    firebaseAuthInstance = MockFirebaseAuth();
+    UserMessagingRepo.db = firebaseFireStoreInstance;
+    UserMessagingRepo.firebaseAuth = firebaseAuthInstance;
+
+    await firebaseFireStoreInstance.collection('Users').doc('1').set({
+      'userId': '1',
+      'UserName': 'Test',
+      'isBlocked': false,
+      'location': {'address': '', 'latitude': 0, 'longitude': 0},
+      'Pictures': []
+    });
+
+    final user = await UserMessagingRepo.getChatUserDetails(userId: '1');
+    expect(user.id, '1');
+  });
+}


### PR DESCRIPTION
## Summary
- add injectable functions to `MatchUserBloc` and `SwipeBloc`
- expose firestore/auth instances for testing
- update repos to support injection
- add bloc tests for registration, match, and swipe
- add simple repository tests
- include test helpers packages

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684b242e26288325a0c08c1f0e7e6a0d