### PR TITLE
Remove google_maps_webservice_ex dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,7 +74,6 @@ dependencies:
   uuid: ^4.5.1                   # Updated to latest
   webview_flutter: ^4.13.0       # Updated to latest
   http: ^1.2.1
-  google_maps_webservice_ex: ^0.0.1-dev.8
   google_fonts: ^6.2.1
   flutter_google_places_hoc081098: ^2.0.0
 


### PR DESCRIPTION
## Summary
- remove `google_maps_webservice_ex` from `pubspec.yaml`

## Testing
- `flutter pub get` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b23f7eab88325a27fc30bb6f443bb