### PR TITLE
Update firebase_auth_mocks to avoid firebase_core conflict

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,7 +87,7 @@ dev_dependencies:
   bloc_test: ^10.0.0
   mocktail: ^1.0.4
   fake_cloud_firestore: ^2.4.1
-  firebase_auth_mocks: ^0.13.0
+  firebase_auth_mocks: ^0.14.2
 
 flutter_icons:
   android: "launcher_icon"


### PR DESCRIPTION
## Summary
- bump `firebase_auth_mocks` dev dependency to `^0.14.2`

## Testing
- `flutter pub get` *(fails: `flutter: command not found`)*
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ad58796c88325bcf2ad1d287706a7