### PR TITLE
Remove const usage in PurchaseVerificationData

### DIFF
--- a/test/payment/in_app_purchase_repo_test.dart
+++ b/test/payment/in_app_purchase_repo_test.dart
@@ -8,7 +8,7 @@ void main() {
       final purchase1 = PurchaseDetails(
         productID: 'id1',
         purchaseID: '1',
-        verificationData: const PurchaseVerificationData(
+        verificationData: PurchaseVerificationData(
           localVerificationData: 'local',
           serverVerificationData: 'server',
           source: 'test',
@@ -19,7 +19,7 @@ void main() {
       final purchase2 = PurchaseDetails(
         productID: 'id2',
         purchaseID: '2',
-        verificationData: const PurchaseVerificationData(
+        verificationData: PurchaseVerificationData(
           localVerificationData: 'local',
           serverVerificationData: 'server',
           source: 'test',


### PR DESCRIPTION
## Summary
- fix `in_app_purchase_repo_test.dart` by dropping unnecessary `const` keywords

## Testing
- `flutter test test/payment/in_app_purchase_repo_test.dart` *(fails: command not found)*
- `dart test test/payment/in_app_purchase_repo_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b33f5185483259db76354ec8609f4