### PR TITLE
Fix getMatches distance check

### DIFF
--- a/lib/common/data/repo/user_messaging_repo.dart
+++ b/lib/common/data/repo/user_messaging_repo.dart
@@ -29,9 +29,18 @@ class UserMessagingRepo {
             await docRef.doc(documentSnapshot['Matches']).get();
         if (doc.exists) {
           UserModel tempuser = UserModel.fromDocument(doc);
-          tempuser.distanceBW = calculateDistance(currentUser.latitude,
-                  currentUser.longitude, tempuser.latitude, tempuser.longitude)
-              .round();
+          if (currentUser.latitude != null &&
+              currentUser.longitude != null &&
+              tempuser.latitude != null &&
+              tempuser.longitude != null) {
+            tempuser.distanceBW =
+                calculateDistance(
+                        currentUser.latitude!,
+                        currentUser.longitude!,
+                        tempuser.latitude!,
+                        tempuser.longitude!)
+                    .round();
+          }
           matches.add(tempuser);
           // matches.sort((a, b) => b.lastmsg!.compareTo(
           //     a.lastmsg!)); // Sort by lastmessage in descending order


### PR DESCRIPTION
## Summary
- guard distance calculation in `getMatches`

## Testing
- `flutter test test/match/user_messaging_repo_test.dart -r expanded` *(fails: command not found)*
- `dart test test/match/user_messaging_repo_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b36e4347c8325984c30d4a18076d1