### PR TITLE
Remove const from Align

### DIFF
--- a/lib/features/calling/ui/screens/call.dart
+++ b/lib/features/calling/ui/screens/call.dart
@@ -266,7 +266,7 @@ class CallPageState extends State<CallPage> {
             : Center(
                 child: Stack(
                   children: <Widget>[
-                    const Align(
+                    Align(
                       alignment: Alignment.center,
                       child: Icon(
                         Icons.person,


### PR DESCRIPTION
## Summary
- fix call screen by removing `const` from `Align`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b36f13fbc832596daf585542bae88