### PR TITLE
Fix return types of swipe methods

### DIFF
--- a/lib/common/data/repo/user_search_repo.dart
+++ b/lib/common/data/repo/user_search_repo.dart
@@ -49,7 +49,8 @@ class UserSearchRepo {
     return swipedCount;
   }
 
-  static leftSwipe(UserModel currentUser, UserModel selectedUser) async {
+  static Future<void> leftSwipe(
+      UserModel currentUser, UserModel selectedUser) async {
     await docRef
         .doc(currentUser.id)
         .collection("CheckedUser")
@@ -60,7 +61,8 @@ class UserSearchRepo {
     }, SetOptions(merge: true));
   }
 
-  static rightSwipe(UserModel currentUser, UserModel selectedUser) async {
+  static Future<void> rightSwipe(
+      UserModel currentUser, UserModel selectedUser) async {
     likedByList = await getLikedByList(currentUser);
     if ((likedByList.contains(selectedUser.id) ||
         (selectedUser.isBot ?? false))) {


### PR DESCRIPTION
## Summary
- update `leftSwipe` and `rightSwipe` to return `Future<void>`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b36fa8e5c83258d6d3714bff2cecd