### PR TITLE
Add missing dart:developer imports

### DIFF
--- a/lib/features/blockUser/bloc/bloc_user_list_bloc.dart
+++ b/lib/features/blockUser/bloc/bloc_user_list_bloc.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import '../../../config/app_config.dart';
 import '../../../models/block_user_model.dart';
 import 'package:equatable/equatable.dart';

--- a/lib/features/report/bloc/report_bloc.dart
+++ b/lib/features/report/bloc/report_bloc.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../common/data/repo/report_user.dart';


### PR DESCRIPTION
## Summary
- add `dart:developer` import for log usage in block user list bloc
- add `dart:developer` import for log usage in report bloc

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b36ed27a08325981c3844107403be