### PR TITLE
Fix missing Firestore getter import

### DIFF
--- a/lib/features/home/ui/screens/home_page.dart
+++ b/lib/features/home/ui/screens/home_page.dart
@@ -4,6 +4,7 @@ import 'package:swipable_stack/swipable_stack.dart';
 import 'package:easy_localization/easy_localization.dart';
 
 import '../../../../common/constants/colors.dart';
+import '../../../../common/constants/constants.dart';
 import '../../../../common/utils/swiper_stack.dart';
 import '../../bloc/searchuser_bloc.dart';
 import '../../bloc/swipebloc_bloc.dart';


### PR DESCRIPTION
## Summary
- import constants for Firestore access in home page

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b370ef3b08325a2d7268ef1d3744f