### PR TITLE
Resolve Agora dependency conflict

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: "direct main"
     description:
       name: agora_rtc_engine
-      sha256: f3b2cf4292692a4de45272adae79554f4942624af5049d222ac0dbe981944070
+      sha256: c1379d78722b3f49f3691c72664b55e094bdf384059125a7bb601bd7217928f6
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.2"
+    version: "5.3.1"
   agora_rtm:
     dependency: transitive
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: "direct main"
     description:
       name: agora_uikit
-      sha256: "2c06a3a12a1aeba6dda84c56bef66091fa6b87b11cc96dbff27c092d0697cef7"
+      sha256: "f28a34879c4b3a92997943a4296e8bff1d36c3d17592bf555ce35268991979f8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.10"
+    version: "1.0.4"
   analyzer:
     dependency: transitive
     description:
@@ -698,10 +698,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "9e8c3858111da373efc5aa341de011d9bd23e2c5c5e0c62bccf32438e192d7b1"
+      sha256: "a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "2.0.3"
   flutter_localizations:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,8 +28,8 @@ environment:
 # the latest version available on pub.dev. To see which dependencies have newer
 # versions available, run `flutter pub outdated`.
 dependencies:
-  agora_rtc_engine: ^6.5.2       # Updated to latest
-  agora_uikit: ^1.3.10           # Upgraded from 1.3.8
+  agora_rtc_engine: 5.3.1
+  agora_uikit: 1.0.4
   cached_network_image: ^3.4.1   # Updated to latest
   cloud_firestore: ^5.6.9        # Updated to latest
   cloud_functions: ^5.5.2        # Updated to latest
@@ -80,7 +80,7 @@ dependencies:
 
 dev_dependencies:
   flutter_launcher_icons: "^0.14.4" # Updated launcher icons
-  flutter_lints: ^3.0.2           # Updated lints version
+  flutter_lints: ^2.0.3
   device_preview: ^1.2.0            # Upgraded from 1.1.0
   flutter_native_splash: ^2.4.6     # Updated to latest
   flutter_test:


### PR DESCRIPTION
## Summary
- downgrade Agora packages to use `NetworkQuality`
- match `flutter_lints` version with Agora UIKit

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b35693e00832586cecb65f8fbc0f6