### PR TITLE
Update http dependency

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -873,10 +873,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
+      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "0.13.6"
   http_multi_server:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,7 +73,7 @@ dependencies:
   swipable_stack: ^2.0.0         # Kept at 2.0.0
   uuid: ^4.5.1                   # Updated to latest
   webview_flutter: ^4.13.0       # Updated to latest
-  http: ^1.2.1
+  http: ^0.13.6
   google_fonts: ^6.2.1
   flutter_google_places_hoc081098: ^2.0.0
   flutter_facebook_auth: ^7.1.2


### PR DESCRIPTION
## Summary
- downgrade `http` dependency to `^0.13.6`
- lock `pubspec.lock` with matching `http` version

## Testing
- `flutter pub get` *(fails: `flutter: command not found`)*
- `flutter analyze` *(fails: `flutter: command not found`)*
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684b6661291483258e5cbe7b276f1429