### PR TITLE
Update Agora package versions

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: "direct main"
     description:
       name: agora_rtc_engine
-      sha256: c1379d78722b3f49f3691c72664b55e094bdf384059125a7bb601bd7217928f6
+      sha256: f3b2cf4292692a4de45272adae79554f4942624af5049d222ac0dbe981944070
       url: "https://pub.dev"
     source: hosted
-    version: "5.3.1"
+    version: "6.5.2"
   agora_rtm:
     dependency: transitive
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: "direct main"
     description:
       name: agora_uikit
-      sha256: "f28a34879c4b3a92997943a4296e8bff1d36c3d17592bf555ce35268991979f8"
+      sha256: 2c06a3a12a1aeba6dda84c56bef66091fa6b87b11cc96dbff27c092d0697cef7
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.3.10"
   analyzer:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,8 +28,8 @@ environment:
 # the latest version available on pub.dev. To see which dependencies have newer
 # versions available, run `flutter pub outdated`.
 dependencies:
-  agora_rtc_engine: 5.3.1
-  agora_uikit: 1.0.4
+  agora_rtc_engine: ^6.5.2
+  agora_uikit: ^1.3.10
   cached_network_image: ^3.4.1   # Updated to latest
   cloud_firestore: ^5.6.9        # Updated to latest
   cloud_functions: ^5.5.2        # Updated to latest


### PR DESCRIPTION
## Summary
- bump `agora_rtc_engine` to `^6.5.2`
- bump `agora_uikit` to `^1.3.10`
- update lockfile checksums

## Testing
- `flutter pub upgrade` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*
- `flutter build apk` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b7359b0e48325be756ee1eb2cdc4b