### PR TITLE
Fix Facebook token property

### DIFF
--- a/lib/common/data/repo/facebooklogin_repo.dart
+++ b/lib/common/data/repo/facebooklogin_repo.dart
@@ -16,7 +16,7 @@ class FaceBookLoginRepositoryImpl implements FaceBookLoginRepository {
       final accessToken = result.accessToken;
 
       // Get the token string directly from the accessToken
-      final tokenString = accessToken?.token ?? '';
+      final tokenString = accessToken?.tokenString ?? '';
       final user = await _provideFirebaseUser(accessToken: tokenString);
       return user;
     } else if (status == LoginStatus.cancelled ||


### PR DESCRIPTION
## Summary
- use `tokenString` when accessing Facebook login token

## Testing
- `flutter analyze` *(fails: `flutter` command not found)*
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b83228cf08325b8c27ceac6a1df12