### PR TITLE
Remove unused imports

### DIFF
--- a/lib/features/home/controllers/home_controller.dart
+++ b/lib/features/home/controllers/home_controller.dart
@@ -9,8 +9,6 @@ import 'package:naijasingles/features/ads/load_ads.dart';
 import '../../../common/data/repo/user_search_repo.dart';
 import '../../../common/providers/user_provider.dart';
 import '../../../models/user_model.dart';
-import '../../../common/constants/constants.dart';
-
 class AdsManager {
   InterstitialAd? interstitialAd;
   bool isInterstitialAdReady = false;

--- a/lib/features/home/ui/screens/home_page.dart
+++ b/lib/features/home/ui/screens/home_page.dart
@@ -1,13 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:swipable_stack/swipable_stack.dart';
-import 'package:easy_localization/easy_localization.dart';
-
-import '../../../../common/constants/colors.dart';
-import '../../../../common/constants/constants.dart';
-import '../../../../common/utils/swiper_stack.dart';
-import '../../bloc/searchuser_bloc.dart';
-import '../../bloc/swipebloc_bloc.dart';
 import '../widgets/premium_swipe.dart';
 import '../widgets/swipe_card_list.dart';
 import '../widgets/swipe_buttons.dart';

--- a/test/match/user_messaging_repo_test.dart
+++ b/test/match/user_messaging_repo_test.dart
@@ -3,8 +3,6 @@ import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:naijasingles/common/constants/constants.dart';
 import 'package:naijasingles/common/data/repo/user_messaging_repo.dart';
-import 'package:naijasingles/models/user_model.dart';
-
 void main() {
   test('getChatUserDetails returns user data', () async {
     firebaseFireStoreInstance = FakeFirebaseFirestore();


### PR DESCRIPTION
## Summary
- clean up home controller imports
- prune unused imports from home page
- drop unnecessary test import

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b8325ae7883258b84be1e5f011988