### PR TITLE
Remove floating label parameter

### DIFF
--- a/lib/features/chat/ui/widgets/send_message_box.dart
+++ b/lib/features/chat/ui/widgets/send_message_box.dart
@@ -297,7 +297,6 @@ class _MessageBoxState extends State<MessageBox> {
                         });
                       },
                       decoration: InputDecoration.collapsed(
-                          floatingLabelBehavior: FloatingLabelBehavior.auto,
                           hintStyle: const TextStyle(color: Colors.grey),
                           hintText: "Send a message...".tr().toString()),
                     ),


### PR DESCRIPTION
## Summary
- clean up chat message box decoration by removing unused floating label behavior

## Testing
- `flutter analyze` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b833a6f0c83258dd7151805527dd8