### PR TITLE
Remove leftover ad comments

### DIFF
--- a/lib/features/chat/ui/screens/chat_page.dart
+++ b/lib/features/chat/ui/screens/chat_page.dart
@@ -7,11 +7,8 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-// import 'package:google_mobile_ads/google_mobile_ads.dart'; // Removed - No longer using ads
 import 'package:naijasingles/common/utils/custom_toast.dart';
 import 'package:naijasingles/common/widgets/custom_snackbar.dart';
-// import 'package:naijasingles/features/ads/google_ads.dart'; // Removed - No longer using ads
-// import 'package:naijasingles/features/ads/load_ads.dart'; // Removed - No longer using ads
 import 'package:naijasingles/features/chat/ui/widgets/send_message_box.dart';
 import 'package:naijasingles/models/user_model.dart';
 import 'package:provider/provider.dart';
@@ -39,7 +36,6 @@ class ChatPage extends StatefulWidget {
 }
 
 class ChatPageState extends State<ChatPage> {
-  // Ad-related variables removed - No longer using ads
   bool isBlocked = false;
   Timer? debouncer;
   bool isCalling = false; // Flag to track if onJoin is in progress
@@ -50,8 +46,6 @@ class ChatPageState extends State<ChatPage> {
 
   @override
   void initState() {
-    // Ad loading removed - No longer using ads
-
     super.initState();
 
     chatReference =
@@ -61,7 +55,6 @@ class ChatPageState extends State<ChatPage> {
 
   @override
   void dispose() {
-    // Ad disposal removed - No longer using ads
     debouncer?.cancel();
     super.dispose();
   }

--- a/lib/features/home/ui/screens/user_filter/settings.dart
+++ b/lib/features/home/ui/screens/user_filter/settings.dart
@@ -6,7 +6,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:naijasingles/common/routes/route_name.dart';
 import 'package:naijasingles/common/widgets/text_button.dart';
-// import 'package:naijasingles/features/ads/google_ads.dart'; // Removed - No longer using ads
 import 'package:naijasingles/features/home/ui/widgets/street_view_enable.dart';
 import 'package:naijasingles/models/user_model.dart';
 import 'package:provider/provider.dart';
@@ -42,7 +41,6 @@ class SettingPage extends StatefulWidget {
 
 class SettingPageState extends State<SettingPage> {
   Map<String, dynamic> changeValues = {};
-  // Banner ad removed - No longer using ads
 
   Future<bool> _onWillPop(BuildContext context) async {
     final currentstate = BlocProvider.of<UserfilterBloc>(context).state;
@@ -105,7 +103,6 @@ class SettingPageState extends State<SettingPage> {
   @override
   void initState() {
     super.initState();
-    // Ad initialization removed - No longer using ads
     freeR = widget.items['free_radius'] != null
         ? int.parse(widget.items['free_radius'])
         : 400;
@@ -124,7 +121,6 @@ class SettingPageState extends State<SettingPage> {
 
   @override
   void dispose() {
-    myBanner.dispose();
     super.dispose();
   }
 
@@ -203,7 +199,6 @@ class SettingPageState extends State<SettingPage> {
                             fontWeight: FontWeight.w500),
                       ),
                     ),
-                    // Ad widget removed - No longer using ads
                     ListTile(
                       title: Card(
                           child: Padding(
@@ -237,7 +232,6 @@ class SettingPageState extends State<SettingPage> {
                             Navigator.pushNamed(
                                 context, RouteName.updatePhoneScreen,
                                 arguments: widget.currentUser);
-                            //      _ads.disable(_ad);
                           },
                         ),
                       )),

--- a/lib/features/user/ui/screens/user_name.dart
+++ b/lib/features/user/ui/screens/user_name.dart
@@ -1,4 +1,3 @@
-//import 'package:firebase_admob/firebase_admob.dart';
 import 'dart:developer';
 
 import 'package:easy_localization/easy_localization.dart';
@@ -18,8 +17,6 @@ class UserName extends StatefulWidget {
   UserNameState createState() => UserNameState();
 }
 
-// late BannerAd ad1;
-// Ads ads = new Ads();
 
 class UserNameState extends State<UserName> {
   Map<String, dynamic> userData = {}; //user personal info
@@ -27,19 +24,11 @@ class UserNameState extends State<UserName> {
 
   @override
   void initState() {
-    //  ad1 = ads.myBanner();
     super.initState();
-    // ad1
-    //   ..load()
-    //   ..show(
-    //     anchorOffset: 180.0,
-    //     anchorType: AnchorType.bottom,
-    //   );
   }
 
   @override
   void dispose() {
-    // ads.disable(ad1);
     super.dispose();
   }
 


### PR DESCRIPTION
## Summary
- strip ad-related imports and comments from chat screen
- remove unused ad code from settings screen
- clean up ad references from user name screen

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b8f1087988325b7857b5f69a1bc29