### PR TITLE
Add location permissions setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,13 @@ NaijaSingles is a Flutter-based mobile dating application created for singles in
 5. After setup completes, run the app on a connected device or emulator:
 
    ```bash
-   flutter run
-   ```
+    flutter run
+    ```
+
+6. Grant location permissions when prompted. The app depends on precise
+   location access to match nearby users. Android permissions are declared
+   in `android/app/src/main/AndroidManifest.xml`, and iOS requires
+   `NSLocationWhenInUseUsageDescription` in `ios/Runner/Info.plist`.
 
 ### Using Emulators
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <application
         android:label="naijasingles"
         android:name="${applicationName}"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -81,9 +81,13 @@
 	</array>
 	<key>CFBundleGetInfoString</key>
 	<string></string>
-	<key>NSLocalNetworkUsageDescription</key>
-	<string>This app uses the local network for development tools.</string>
-	<key>LSApplicationQueriesSchemes</key>
+        <key>NSLocalNetworkUsageDescription</key>
+        <string>This app uses the local network for development tools.</string>
+        <key>NSLocationWhenInUseUsageDescription</key>
+        <string>Your location is used to find nearby matches.</string>
+        <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+        <string>Your location is needed to provide personalized services.</string>
+        <key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>fbapi</string>
 		<string>fb-messenger-share-api</string>

--- a/lib/common/data/repo/user_location_repo.dart
+++ b/lib/common/data/repo/user_location_repo.dart
@@ -52,21 +52,16 @@ class UserLocationReporistoryImpl implements UserLocationReporistory {
       // Get location with timeout
       loc.LocationData? coordinates;
       try {
-        coordinates = await Future.delayed(const Duration(seconds: 10), () async {
-          try {
-            return await location.getLocation();
-          } catch (e) {
-            log("Error getting location: ${e.toString()}");
-            return null;
-          }
-        });
-        
-        if (coordinates == null) {
-          log("Location request timed out");
-          return getDefaultLocation();
-        }
+        coordinates = await location
+            .getLocation()
+            .timeout(const Duration(seconds: 10));
       } catch (e) {
         log("Error getting location with timeout: ${e.toString()}");
+        return getDefaultLocation();
+      }
+
+      if (coordinates == null) {
+        log("Location request timed out");
         return getDefaultLocation();
       }
       


### PR DESCRIPTION
## Summary
- declare fine and coarse location permission on Android
- add location usage description for iOS
- fetch location with timeout using `location.getLocation()`
- document permission requirements in README

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef5e19f6883258ecc7d9cb1ad098e