### PR TITLE
Add diary feature

### DIFF
--- a/lib/common/routes/route_name.dart
+++ b/lib/common/routes/route_name.dart
@@ -25,4 +25,5 @@ class RouteName {
   static const String chatPageScreen = '/chat_page';
   static const String userDobScreen = '/user_dob';
   static const String nationalityScreen = '/nationality';
+  static const String diaryFeed = '/diary_feed';
 }

--- a/lib/common/routes/router.dart
+++ b/lib/common/routes/router.dart
@@ -23,6 +23,7 @@ import 'package:naijasingles/models/user_model.dart';
 import 'package:provider/provider.dart';
 import '../../features/home/ui/screens/user_filter/settings.dart';
 import '../../features/home/ui/screens/welcome.dart';
+import '../../features/diary/ui/screens/diary_feed.dart';
 import 'package:naijasingles/features/user/ui/screens/user_dob.dart';
 import 'package:naijasingles/features/user/ui/screens/user_gender.dart';
 import 'package:naijasingles/features/user/ui/screens/user_name.dart';
@@ -94,5 +95,6 @@ abstract class AppRouter {
     RouteName.userNameScreen: (context) => const UserName(),
     RouteName.nationalityScreen: (context) => UserNationality(
         ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>),
+    RouteName.diaryFeed: (context) => const DiaryFeedPage(),
   };
 }

--- a/lib/features/diary/bloc/diary_bloc.dart
+++ b/lib/features/diary/bloc/diary_bloc.dart
@@ -1,0 +1,62 @@
+import 'dart:async';
+
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../data/diary_repository.dart';
+
+part 'diary_event.dart';
+part 'diary_state.dart';
+
+class DiaryBloc extends Bloc<DiaryEvent, DiaryState> {
+  final DiaryRepository repository;
+  StreamSubscription<List<DiaryEntry>>? _subscription;
+
+  DiaryBloc({required this.repository}) : super(DiaryInitial()) {
+    on<LoadDiaryEntries>(_onLoad);
+    on<AddDiaryEntryEvent>(_onAdd);
+    on<_DiaryEntriesUpdated>(_onEntriesUpdated);
+  }
+
+  Future<void> _onLoad(
+      LoadDiaryEntries event, Emitter<DiaryState> emit) async {
+    emit(DiaryLoading());
+    await _subscription?.cancel();
+    _subscription = repository.entriesStream().listen((entries) {
+      add(_DiaryEntriesUpdated(entries));
+    });
+  }
+
+  Future<void> _onAdd(
+      AddDiaryEntryEvent event, Emitter<DiaryState> emit) async {
+    try {
+      await repository.addEntry(
+        userId: event.userId,
+        content: event.content,
+        userName: event.userName,
+        userImage: event.userImage,
+      );
+    } catch (e) {
+      emit(DiaryError(e.toString()));
+    }
+  }
+
+  @override
+  Future<void> close() {
+    _subscription?.cancel();
+    return super.close();
+  }
+
+  void _onEntriesUpdated(
+      _DiaryEntriesUpdated event, Emitter<DiaryState> emit) {
+    emit(DiaryLoaded(event.entries));
+  }
+}
+
+class _DiaryEntriesUpdated extends DiaryEvent {
+  final List<DiaryEntry> entries;
+  const _DiaryEntriesUpdated(this.entries);
+
+  @override
+  List<Object> get props => [entries];
+}

--- a/lib/features/diary/bloc/diary_event.dart
+++ b/lib/features/diary/bloc/diary_event.dart
@@ -1,0 +1,27 @@
+part of 'diary_bloc.dart';
+
+abstract class DiaryEvent extends Equatable {
+  const DiaryEvent();
+
+  @override
+  List<Object> get props => [];
+}
+
+class LoadDiaryEntries extends DiaryEvent {}
+
+class AddDiaryEntryEvent extends DiaryEvent {
+  final String userId;
+  final String content;
+  final String userName;
+  final String? userImage;
+
+  const AddDiaryEntryEvent({
+    required this.userId,
+    required this.content,
+    required this.userName,
+    required this.userImage,
+  });
+
+  @override
+  List<Object> get props => [userId, content, userName, userImage ?? ''];
+}

--- a/lib/features/diary/bloc/diary_state.dart
+++ b/lib/features/diary/bloc/diary_state.dart
@@ -1,0 +1,30 @@
+part of 'diary_bloc.dart';
+
+abstract class DiaryState extends Equatable {
+  const DiaryState();
+
+  @override
+  List<Object> get props => [];
+}
+
+class DiaryInitial extends DiaryState {}
+
+class DiaryLoading extends DiaryState {}
+
+class DiaryLoaded extends DiaryState {
+  final List<DiaryEntry> entries;
+
+  const DiaryLoaded(this.entries);
+
+  @override
+  List<Object> get props => [entries];
+}
+
+class DiaryError extends DiaryState {
+  final String message;
+
+  const DiaryError(this.message);
+
+  @override
+  List<Object> get props => [message];
+}

--- a/lib/features/diary/data/diary_repository.dart
+++ b/lib/features/diary/data/diary_repository.dart
@@ -1,0 +1,62 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../../common/constants/constants.dart';
+
+class DiaryEntry {
+  final String id;
+  final String userId;
+  final String content;
+  final Timestamp timestamp;
+  final String userName;
+  final String? userImage;
+
+  DiaryEntry({
+    required this.id,
+    required this.userId,
+    required this.content,
+    required this.timestamp,
+    required this.userName,
+    required this.userImage,
+  });
+
+  factory DiaryEntry.fromDocument(DocumentSnapshot doc) {
+    return DiaryEntry(
+      id: doc.id,
+      userId: doc['userId'] as String,
+      content: doc['content'] as String,
+      timestamp: doc['timestamp'] as Timestamp,
+      userName: doc['userName'] as String? ?? '',
+      userImage: doc['userImage'] as String?,
+    );
+  }
+}
+
+class DiaryRepository {
+  final CollectionReference diaryRef =
+      firebaseFireStoreInstance.collection('diaryEntries');
+
+  Future<void> addEntry({
+    required String userId,
+    required String content,
+    required String userName,
+    required String? userImage,
+  }) async {
+    await diaryRef.add({
+      'userId': userId,
+      'content': content,
+      'userName': userName,
+      'userImage': userImage,
+      'timestamp': FieldValue.serverTimestamp(),
+    });
+  }
+
+  Stream<List<DiaryEntry>> entriesStream() {
+    return diaryRef
+        .orderBy('timestamp', descending: true)
+        .snapshots()
+        .map((snapshot) => snapshot.docs
+            .where((doc) => doc.data() != null)
+            .map((doc) => DiaryEntry.fromDocument(doc))
+            .toList());
+  }
+}

--- a/lib/features/diary/ui/screens/diary_feed.dart
+++ b/lib/features/diary/ui/screens/diary_feed.dart
@@ -1,0 +1,116 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:provider/provider.dart';
+
+import '../../../../common/providers/user_provider.dart';
+import '../../bloc/diary_bloc.dart';
+import '../../data/diary_repository.dart';
+
+class DiaryFeedScreen extends StatefulWidget {
+  const DiaryFeedScreen({super.key});
+
+  @override
+  State<DiaryFeedScreen> createState() => _DiaryFeedScreenState();
+}
+
+class _DiaryFeedScreenState extends State<DiaryFeedScreen> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    context.read<DiaryBloc>().add(LoadDiaryEntries());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final user = Provider.of<UserProvider>(context).currentUser!;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Diary Feed'.tr()),
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _controller,
+                    decoration:
+                        InputDecoration(hintText: 'Write something...'.tr()),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.send),
+                  onPressed: () {
+                    final text = _controller.text.trim();
+                    if (text.isNotEmpty) {
+                      context.read<DiaryBloc>().add(AddDiaryEntryEvent(
+                            userId: user.id!,
+                            content: text,
+                            userName: user.name ?? '',
+                            userImage:
+                                user.imageUrl != null && user.imageUrl!.isNotEmpty
+                                    ? user.imageUrl!.first
+                                    : null,
+                          ));
+                      _controller.clear();
+                    }
+                  },
+                )
+              ],
+            ),
+          ),
+          Expanded(
+            child: BlocBuilder<DiaryBloc, DiaryState>(
+              builder: (context, state) {
+                if (state is DiaryLoading) {
+                  return const Center(child: CircularProgressIndicator());
+                } else if (state is DiaryLoaded) {
+                  if (state.entries.isEmpty) {
+                    return Center(child: Text('No entries'.tr()));
+                  }
+                  return ListView.builder(
+                    itemCount: state.entries.length,
+                    itemBuilder: (context, index) {
+                      final entry = state.entries[index];
+                      return ListTile(
+                        leading: entry.userImage != null
+                            ? CircleAvatar(
+                                backgroundImage: NetworkImage(entry.userImage!),
+                              )
+                            : const CircleAvatar(child: Icon(Icons.person)),
+                        title: Text(entry.userName),
+                        subtitle: Text(entry.content),
+                        trailing: Text(DateFormat('MMM d, HH:mm')
+                            .format(entry.timestamp.toDate())),
+                      );
+                    },
+                  );
+                } else if (state is DiaryError) {
+                  return Center(child: Text(state.message));
+                }
+                return const SizedBox.shrink();
+              },
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}
+
+class DiaryFeedPage extends StatelessWidget {
+  const DiaryFeedPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => DiaryBloc(repository: DiaryRepository()),
+      child: const DiaryFeedScreen(),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- allow users to post short diary entries
- show a scrollable diary feed
- add `/diary_feed` route

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f9997c6c4832595b822e1574ccfc2