### PR TITLE
Add tribe & diaspora fields to onboarding

### DIFF
--- a/lib/features/user/ui/screens/user_nationality.dart
+++ b/lib/features/user/ui/screens/user_nationality.dart
@@ -17,8 +17,10 @@ class UserNationality extends StatefulWidget {
 class _UserNationalityState extends State<UserNationality> {
   String selectedCountry = '';
   final TextEditingController _searchController = TextEditingController();
+  final TextEditingController _tribeController = TextEditingController();
   final FocusNode _searchFocusNode = FocusNode();
   final ScrollController _scrollController = ScrollController();
+  bool isDiaspora = false;
   
   // List of countries
   final List<String> countries = [
@@ -64,6 +66,7 @@ class _UserNationalityState extends State<UserNationality> {
   @override
   void dispose() {
     _searchController.dispose();
+    _tribeController.dispose();
     _searchFocusNode.dispose();
     _scrollController.dispose();
     super.dispose();
@@ -200,7 +203,37 @@ class _UserNationalityState extends State<UserNationality> {
                   ],
                 ),
               ),
-              
+
+              const SizedBox(height: 20),
+
+              TextField(
+                controller: _tribeController,
+                decoration: InputDecoration(
+                  labelText: 'Tribe (optional)',
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                ),
+              ),
+
+              const SizedBox(height: 20),
+
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Text('Are you in the diaspora?'),
+                  Switch(
+                    value: isDiaspora,
+                    activeColor: const Color(0xFF27AE60),
+                    onChanged: (val) {
+                      setState(() {
+                        isDiaspora = val;
+                      });
+                    },
+                  ),
+                ],
+              ),
+
               const SizedBox(height: 20),
               
               // Countries list
@@ -269,7 +302,11 @@ class _UserNationalityState extends State<UserNationality> {
                     color: const Color(0xFF27AE60),
                     onTap: () {
                       if (selectedCountry.isNotEmpty) {
-                        widget.userData.addAll({'nationality': selectedCountry});
+                        widget.userData.addAll({
+                          'nationality': selectedCountry,
+                          'tribe': _tribeController.text.trim(),
+                          'isDiaspora': isDiaspora,
+                        });
                         log(widget.userData.toString());
                         Navigator.pushNamed(context, RouteName.sexualorientationScreen,
                             arguments: widget.userData);

--- a/lib/models/user_model.dart
+++ b/lib/models/user_model.dart
@@ -28,6 +28,10 @@ class UserModel {
   final Map? editInfo;
   final Map? streetView;
   final bool? isBot;
+  final String? tribe;
+  final List? languagesSpoken;
+  final bool? isDiaspora;
+  final String? intent;
   List? imageUrl = [];
   // ignore: prefer_typing_uninitialized_variables
   var distanceBW;
@@ -57,11 +61,15 @@ class UserModel {
     this.streetView,
     this.distanceBW,
     this.sexualOrientation,
+    this.tribe,
+    this.languagesSpoken,
+    this.isDiaspora,
+    this.intent,
   });
 
   @override
   String toString() {
-    return 'User: {id: $id,name:$name, isBlocked: $isBlocked, address: $address, coordinates: $coordinates,currentCoordinates :$currentCoordinates,  sexualOrientation: $sexualOrientation, gender: $userGender, showGender: $showGender, age: $age, phoneNumber: $phoneNumber, maxDistance: $maxDistance, lastmsg: $lastmsg, ageRange: $ageRange, editInfo: $editInfo, streetView: $streetView ,  distanceBW : $distanceBW, isBot:$isBot }';
+    return 'User: {id: $id,name:$name, isBlocked: $isBlocked, address: $address, coordinates: $coordinates,currentCoordinates :$currentCoordinates,  sexualOrientation: $sexualOrientation, gender: $userGender, showGender: $showGender, age: $age, phoneNumber: $phoneNumber, maxDistance: $maxDistance, lastmsg: $lastmsg, ageRange: $ageRange, editInfo: $editInfo, streetView: $streetView ,  distanceBW : $distanceBW, tribe:$tribe, languagesSpoken:$languagesSpoken, isDiaspora:$isDiaspora, intent:$intent, isBot:$isBot }';
   }
 
   factory UserModel.fromDocument(DocumentSnapshot doc) {
@@ -127,6 +135,14 @@ class UserModel {
       isBot: doc.data().toString().contains('isBot')
           ? doc.get('isBot') ?? false
           : false,
+      tribe: doc.data().toString().contains('tribe') ? doc.get('tribe') ?? '' : '',
+      languagesSpoken: doc.data().toString().contains('languages_spoken')
+          ? doc.get('languages_spoken') ?? []
+          : [],
+      isDiaspora: doc.data().toString().contains('isDiaspora')
+          ? doc.get('isDiaspora') ?? false
+          : false,
+      intent: doc.data().toString().contains('intent') ? doc.get('intent') ?? '' : '',
       imageUrl: doc.get('Pictures') != null
           ? List.generate(doc.get('Pictures').length, (index) {
               return doc.get('Pictures')[index];
@@ -161,7 +177,11 @@ class UserModel {
         streetView: json['streetView'],
         imageUrl: json['Pictures'],
         distanceBW: json['distanceBW'] ?? 0,
-        isBot: json['isBot'] ?? false);
+        isBot: json['isBot'] ?? false,
+        tribe: json['tribe'],
+        languagesSpoken: json['languages_spoken'],
+        isDiaspora: json['isDiaspora'],
+        intent: json['intent']);
   }
 
   static UserModel convertStringToUserModel(String userString) {


### PR DESCRIPTION
## Summary
- persist user's tribe, languages, diaspora status and intent in `UserModel`
- collect tribe and diaspora fields on nationality screen

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f999975a08325b58b1e6a1e3f1cba