### PR TITLE
Add simple development login screen

### DIFF
--- a/lib/common/data/repo/phone_auth_repo.dart
+++ b/lib/common/data/repo/phone_auth_repo.dart
@@ -35,11 +35,12 @@ class PhoneAuthRepository {
         codeSent: (verificationId, resendToken) {
           log("📩 Test code sent. Verification ID: $verificationId");
           
-          // For test phone numbers in the emulator, we know the code is always '000000'
-          // We can create the credential here and complete the verification
+          // For test phone numbers in the emulator, we know the code is always
+          // '123456'. We can create the credential here and complete the
+          // verification
           final testCredential = PhoneAuthProvider.credential(
             verificationId: verificationId,
-            smsCode: '000000',
+            smsCode: '123456',
           );
           
           // Call the original codeSent callback first
@@ -94,7 +95,7 @@ class PhoneAuthRepository {
       
       // When using Firebase Auth Emulator with test phone numbers:
       // 1. We need to use a specific test phone number format
-      // 2. The verification code is always '000000'
+      // 2. The verification code provided by the emulator is '123456'
       
       // First, sign in directly with the test phone number
       final phoneNumber = '+12179044453'; // This is a test phone number format
@@ -124,11 +125,11 @@ class PhoneAuthRepository {
         codeSent: (String verificationId, int? resendToken) async {
           try {
             log("📩 Code sent for test phone. Using verification ID: $verificationId");
-            
-            // For Firebase Auth Emulator, the verification code is always '000000'
+
+            // For Firebase Auth Emulator, the verification code is always '123456'
             final credential = PhoneAuthProvider.credential(
               verificationId: verificationId,
-              smsCode: '000000',
+              smsCode: '123456',
             );
             
             // Sign in with the credential

--- a/lib/common/routes/router.dart
+++ b/lib/common/routes/router.dart
@@ -27,7 +27,7 @@ import 'package:naijasingles/features/user/ui/screens/user_dob.dart';
 import 'package:naijasingles/features/user/ui/screens/user_gender.dart';
 import 'package:naijasingles/features/user/ui/screens/user_name.dart';
 
-import '../../features/auth/phone/ui/screens/login_option_page.dart';
+import '../../features/auth/dev_login/dev_login_screen.dart';
 import '../../features/auth/phone/ui/screens/otp_page.dart';
 import '../../features/home/ui/screens/splash.dart';
 
@@ -35,7 +35,7 @@ abstract class AppRouter {
   // register here for routes
   static Map<String, WidgetBuilder> allRoutes = {
     RouteName.splashScreen: (context) => const Splash(),
-    RouteName.loginScreen: (context) => const LoginOption(),
+    RouteName.loginScreen: (context) => const DevLoginScreen(),
     RouteName.tabScreen: (context) => const Tabbar("active", false),
     RouteName.profileScreen: (context) => ProfilePage(
           isPuchased:

--- a/lib/features/auth/dev_login/dev_login_screen.dart
+++ b/lib/features/auth/dev_login/dev_login_screen.dart
@@ -1,0 +1,116 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import '../../../common/data/repo/phone_auth_repo.dart';
+import '../../../home_page.dart';
+
+class DevLoginScreen extends StatefulWidget {
+  const DevLoginScreen({super.key});
+
+  @override
+  State<DevLoginScreen> createState() => _DevLoginScreenState();
+}
+
+class _DevLoginScreenState extends State<DevLoginScreen> {
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  bool _loading = false;
+  String? _error;
+
+  Future<void> _loginWithEmail() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      await FirebaseAuth.instance.signInWithEmailAndPassword(
+        email: _emailController.text.trim(),
+        password: _passwordController.text,
+      );
+      if (!mounted) return;
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute(builder: (_) => const HomePage()),
+      );
+    } on FirebaseAuthException catch (e) {
+      setState(() => _error = e.message);
+    } finally {
+      setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _loginWithTestPhone() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final repo = PhoneAuthRepository();
+      await repo.signInWithTestPhone();
+      if (!mounted) return;
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute(builder: (_) => const HomePage()),
+      );
+    } on FirebaseAuthException catch (e) {
+      setState(() => _error = e.message);
+    } catch (e) {
+      setState(() => _error = e.toString());
+    } finally {
+      setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Dev Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(
+                labelText: 'Email',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _passwordController,
+              obscureText: true,
+              decoration: const InputDecoration(
+                labelText: 'Password',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 20),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: _loading ? null : _loginWithEmail,
+                child: const Text('Login with Email'),
+              ),
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton(
+                onPressed: _loading ? null : _loginWithTestPhone,
+                child: const Text('Use Test Phone'),
+              ),
+            ),
+            if (_loading) const SizedBox(height: 20),
+            if (_loading) const CircularProgressIndicator(),
+            if (_error != null) ...[
+              const SizedBox(height: 20),
+              Text(
+                _error!,
+                style: const TextStyle(color: Colors.red),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text(
+          'Home Page',
+          style: TextStyle(fontSize: 24),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a minimal HomePage placeholder
- create a DevLoginScreen supporting email and test phone login
- use DevLoginScreen for the login route
- update phone auth repository to use Firebase Auth emulator code `123456`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f950810cc8325b6ea3ce3e3e447bb