### PR TITLE
Bump iOS deployment target

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '14.0'
+platform :ios, '17.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'


### PR DESCRIPTION
## Summary
- bump deployment target in Podfile

## Testing
- `pod install --allow-root` *(fails: Generated.xcconfig missing)*
- `flutter build ios --debug --no-codesign` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503a2c6e988325b90fee0c92ee1596