### PR TITLE
Fix EditProfileScreen build method

### DIFF
--- a/lib/features/profile/edit_profile_screen.dart
+++ b/lib/features/profile/edit_profile_screen.dart
@@ -640,7 +640,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
     if (_selectedDOB != null) {
       final now = DateTime.now();
       int age = now.year - _selectedDOB!.year;
-      if (now.month < _selectedDOB!.month || 
+      if (now.month < _selectedDOB!.month ||
           (now.month == _selectedDOB!.month && now.day < _selectedDOB!.day)) {
         age--;
       }
@@ -649,6 +649,9 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
       });
     }
   }
+
+  @override
+  Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: backgroundColor,
       appBar: AppBar(


### PR DESCRIPTION
## Summary
- add missing `build()` override in `EditProfileScreen`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685843e427048325a34e391670f775f0