### PR TITLE
fix(auth): P1/P2/P3 auth fixes, launch UX (welcome unauthenticated-only)

### DIFF
--- a/lib/features/auth/welcome/welcome_screen.dart
+++ b/lib/features/auth/welcome/welcome_screen.dart
@@ -21,7 +21,6 @@ class WelcomeScreen extends StatefulWidget {
 
 class _WelcomeScreenState extends State<WelcomeScreen>
     with TickerProviderStateMixin {
-  bool _isAuthenticated = false;
   bool _isLoading = true;
 
   // Ken Burns — perpetual slow zoom + pan
@@ -107,18 +106,24 @@ class _WelcomeScreenState extends State<WelcomeScreen>
 
       final currentUser = FirebaseAuth.instance.currentUser;
 
+      if (currentUser != null) {
+        log('User has session — skipping Welcome, navigating via AuthRouter');
+        if (mounted) {
+          await AuthRouter.navigateAfterAuth(context);
+        }
+        return;
+      }
+
       if (mounted) {
         setState(() {
-          _isAuthenticated = currentUser != null;
           _isLoading = false;
         });
-        log("User authentication status: ${_isAuthenticated ? 'Authenticated' : 'Not authenticated'}");
+        log('User not authenticated — showing Welcome (Create Account / Log in)');
       }
     } on Object catch (e) {
       log('Error checking auth status: $e');
       if (mounted) {
         setState(() {
-          _isAuthenticated = false;
           _isLoading = false;
         });
       }
@@ -330,20 +335,6 @@ class _WelcomeScreenState extends State<WelcomeScreen>
 
   Widget _buildButtons(double screenWidth) {
     final buttonWidth = screenWidth * 0.80;
-
-    if (_isAuthenticated) {
-      return Center(
-        child: SizedBox(
-          width: buttonWidth,
-          child: _buildPrimaryButton(
-            text: 'Continue to App',
-            onPressed: () => unawaited(
-              AuthRouter.navigateAfterAuth(context),
-            ),
-          ),
-        ),
-      );
-    }
 
     return Column(
       mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
## Summary
Auth and onboarding security/UX fixes plus launch flow alignment.

## P1/P2/P3 auth and onboarding (existing)
- **P1** Unregistered phone login: fail closed (NotRegistered, signOut, no ensureMinimalUserDocument); OtpPage snackbar + LogoutEvent + pop
- **P1** Onboarding save failure: no navigation to main app from catch block
- **P2** Welcome: Continue to App uses AuthRouter; Create Account → AuthMethodSelectionScreen
- **P2** Google: rethrow FirebaseAuthException for account-exists message
- **P3** Phone validation: dlibphonenumber E.164
- Tests: registration_bloc, welcome_screen, phone_number_widget, phone_validation, otp_page_not_registered, google_login_bloc

## Launch auth flow (new)
- **Welcome** is unauthenticated-only: shows only Create Account and Log in (no Continue to App)
- When a session exists at launch, skip Welcome and call AuthRouter automatically → onboarding or main (no extra tap)
- Removes `_isAuthenticated` and the Continue to App branch from welcome_screen.dart

Made with [Cursor](https://cursor.com)