### PR TITLE
fix(auth): route session users via AuthRouter at launch

### DIFF
--- a/lib/features/auth/welcome/welcome_screen.dart
+++ b/lib/features/auth/welcome/welcome_screen.dart
@@ -104,13 +104,13 @@ class _WelcomeScreenState extends State<WelcomeScreen>
       await Future.delayed(const Duration(milliseconds: 100));
       if (!mounted) return;
 
+      // Session-first launch behavior:
+      // - Returning signed-in users go straight to app home
+      // - Users without a session see auth entry options
       final currentUser = FirebaseAuth.instance.currentUser;
-
       if (currentUser != null) {
-        log('User has session — skipping Welcome, navigating via AuthRouter');
-        if (mounted) {
-          await AuthRouter.navigateAfterAuth(context);
-        }
+        log('User has active session — routing via AuthRouter');
+        await AuthRouter.navigateAfterAuth(context);
         return;
       }
 
@@ -118,7 +118,7 @@ class _WelcomeScreenState extends State<WelcomeScreen>
         setState(() {
           _isLoading = false;
         });
-        log('User not authenticated — showing Welcome (Create Account / Log in)');
+        log('No active session — showing Welcome (Create Account / Log in)');
       }
     } on Object catch (e) {
       log('Error checking auth status: $e');


### PR DESCRIPTION
## Summary
- Returning users with an active Firebase session are routed via `AuthRouter.navigateAfterAuth` at launch (onboarding if profile incomplete, main if complete)
- Users without a session see the Welcome screen with Create Account / Log in only
- Simplified `_checkAuthStatus()` with cleaner comments and log messages

## Context
Follow-up to #148 (merged). The previous commit hardcoded `mainNavigation` which would skip onboarding for users with incomplete profiles. This fix uses `AuthRouter` to handle both cases correctly.

## Test plan
- [x] `flutter test test/features/auth/welcome_screen_test.dart` — all passed

Made with [Cursor](https://cursor.com)