### PR TITLE
fix(auth): handle stale/invalid sessions and tighten profile-completion guard

### DIFF
--- a/lib/common/utils/auth_router.dart
+++ b/lib/common/utils/auth_router.dart
@@ -16,6 +16,12 @@ class AuthRouter {
   AuthRouter._();
 
   static const Duration _newAccountWindow = Duration(minutes: 2);
+  static const Set<String> _supportedProviderIds = <String>{
+    'phone',
+    'google.com',
+    'password',
+    'apple.com',
+  };
 
   /// Reads the current user's Firestore document and navigates to
   /// [RouteName.onboarding] (incomplete profile) or
@@ -27,6 +33,25 @@ class AuthRouter {
     final user = FirebaseAuth.instance.currentUser;
     if (user == null) {
       log('AuthRouter: no authenticated user — returning to welcome');
+      if (context.mounted) {
+        await Navigator.of(context).pushNamedAndRemoveUntil(
+          RouteName.welcomeScreen,
+          (route) => false,
+        );
+      }
+      return;
+    }
+
+    if (_shouldTreatAsSignedOut(user)) {
+      log(
+        'AuthRouter: invalid/stale auth session detected '
+        '(anonymous or unsupported provider) — signing out to welcome',
+      );
+      try {
+        await FirebaseAuth.instance.signOut();
+      } on Object catch (e) {
+        log('AuthRouter: signOut failed while clearing stale session: $e');
+      }
       if (context.mounted) {
         await Navigator.of(context).pushNamedAndRemoveUntil(
           RouteName.welcomeScreen,
@@ -80,5 +105,17 @@ class AuthRouter {
         );
       }
     }
+  }
+
+  static bool _shouldTreatAsSignedOut(User user) {
+    if (user.isAnonymous) return true;
+
+    final providerIds = user.providerData
+        .map((provider) => provider.providerId)
+        .where((id) => id.trim().isNotEmpty)
+        .toSet();
+    if (providerIds.isEmpty) return true;
+
+    return !providerIds.any(_supportedProviderIds.contains);
   }
 }

--- a/lib/common/utils/profile_completion_guard.dart
+++ b/lib/common/utils/profile_completion_guard.dart
@@ -8,6 +8,9 @@ class ProfileCompletionGuard {
 
   static bool _isFalseFlag(Object? value) => value == false;
 
+  static bool _hasNonEmptyList(Map<String, dynamic> data, String key) =>
+      data[key] is List && (data[key] as List).isNotEmpty;
+
   /// Determine profile completeness from raw Firestore document data.
   /// Honors explicit completion flags first, then falls back to basic
   /// required fields for backward compatibility.
@@ -22,21 +25,28 @@ class ProfileCompletionGuard {
       return true;
     }
 
+    final hasName =
+        _isNonEmptyString(data['name']) || _isNonEmptyString(data['userName']);
+    final hasGender = _isNonEmptyString(data['gender']) ||
+        _isNonEmptyString(data['userGender']);
+    final hasPhoto = _hasNonEmptyList(data, 'photos') ||
+        _hasNonEmptyList(data, 'Pictures') ||
+        _hasNonEmptyList(data, 'imageUrl') ||
+        _isNonEmptyString(data['profilePicture']);
+
+    final hasLegacyCompleteSignals = hasName && (hasGender || hasPhoto);
+    final hasStrongCompleteSignals = hasName && hasGender && hasPhoto;
+
+    // Some legacy records have stale `...Completed: false` flags despite
+    // populated profile data. Prefer real profile signals in that case so
+    // returning users are not trapped in onboarding.
     if (_isFalseFlag(onboardingCompleted) ||
         _isFalseFlag(isProfileComplete) ||
         _isFalseFlag(profileSetupComplete)) {
-      return false;
+      return hasStrongCompleteSignals;
     }
 
-    final hasName = _isNonEmptyString(data['name']);
-    final hasGender = _isNonEmptyString(data['gender']) ||
-        _isNonEmptyString(data['userGender']);
-    final photos = data['photos'] is List ? data['photos'] as List : const [];
-    final pictures =
-        data['Pictures'] is List ? data['Pictures'] as List : const [];
-    final hasPhoto = photos.isNotEmpty || pictures.isNotEmpty;
-
-    return hasName && (hasGender || hasPhoto);
+    return hasLegacyCompleteSignals;
   }
 
   /// Determine profile completeness from parsed user model.

--- a/lib/features/auth/welcome/welcome_screen.dart
+++ b/lib/features/auth/welcome/welcome_screen.dart
@@ -22,6 +22,12 @@ class WelcomeScreen extends StatefulWidget {
 class _WelcomeScreenState extends State<WelcomeScreen>
     with TickerProviderStateMixin {
   bool _isLoading = true;
+  static const Set<String> _supportedProviderIds = <String>{
+    'phone',
+    'google.com',
+    'password',
+    'apple.com',
+  };
 
   // Ken Burns — perpetual slow zoom + pan
   late AnimationController _kenBurnsController;
@@ -109,9 +115,19 @@ class _WelcomeScreenState extends State<WelcomeScreen>
       // - Users without a session see auth entry options
       final currentUser = FirebaseAuth.instance.currentUser;
       if (currentUser != null) {
-        log('User has active session — routing via AuthRouter');
-        await AuthRouter.navigateAfterAuth(context);
-        return;
+        // Defensive cleanup for stale/invalid auth sessions that may persist
+        // across TestFlight updates. These users should see auth entry.
+        if (_shouldTreatAsSignedOut(currentUser)) {
+          log(
+            'Invalid/stale auth session detected '
+            '(anonymous or unsupported provider). Signing out.',
+          );
+          await FirebaseAuth.instance.signOut();
+        } else {
+          log('User has active session — routing via AuthRouter');
+          await AuthRouter.navigateAfterAuth(context);
+          return;
+        }
       }
 
       if (mounted) {
@@ -128,6 +144,18 @@ class _WelcomeScreenState extends State<WelcomeScreen>
         });
       }
     }
+  }
+
+  bool _shouldTreatAsSignedOut(User user) {
+    if (user.isAnonymous) return true;
+
+    final providerIds = user.providerData
+        .map((provider) => provider.providerId)
+        .where((id) => id.trim().isNotEmpty)
+        .toSet();
+    if (providerIds.isEmpty) return true;
+
+    return !providerIds.any(_supportedProviderIds.contains);
   }
 
   @override


### PR DESCRIPTION
## Summary
- Stale/invalid Firebase sessions (anonymous, unsupported provider, or carried-over TestFlight credentials) are now signed out automatically so users see Create Account / Log in instead of being routed into onboarding
- ProfileCompletionGuard: when explicit `Completed: false` flags exist but profile has strong signals (name + gender + photo), treat as complete to prevent returning users from being trapped in onboarding

## Changes
- **welcome_screen.dart**: `_checkAuthStatus()` detects stale sessions via `_shouldTreatAsSignedOut()` and signs out before showing auth CTAs
- **auth_router.dart**: Defense-in-depth stale session check with `_supportedProviderIds` allowlist (phone, google.com, password, apple.com)
- **profile_completion_guard.dart**: Strong profile signals override stale `...Completed: false` flags; legacy docs use looser check (name + gender-or-photo)

## Context
Follow-up to #150 (merged). iOS/TestFlight can persist Firebase auth credentials across updates, causing the app to skip Welcome and route to onboarding for stale sessions.

## Test plan
- [x] `flutter test test/features/auth/welcome_screen_test.dart test/features/auth/auth_flow_test.dart test/features/auth/otp_page_not_registered_test.dart test/auth/registration_bloc_test.dart test/features/auth/google_login_bloc_test.dart` — all passed
- [x] `flutter analyze` on changed files — no issues

Made with [Cursor](https://cursor.com)