### PR TITLE
fix(onboarding): prevent infinite spinner on save failure, handle ghost sessions

### DIFF
--- a/lib/common/utils/auth_router.dart
+++ b/lib/common/utils/auth_router.dart
@@ -47,17 +47,7 @@ class AuthRouter {
         'AuthRouter: invalid/stale auth session detected '
         '(anonymous or unsupported provider) — signing out to welcome',
       );
-      try {
-        await FirebaseAuth.instance.signOut();
-      } on Object catch (e) {
-        log('AuthRouter: signOut failed while clearing stale session: $e');
-      }
-      if (context.mounted) {
-        await Navigator.of(context).pushNamedAndRemoveUntil(
-          RouteName.welcomeScreen,
-          (route) => false,
-        );
-      }
+      await _signOutAndGoWelcome(context);
       return;
     }
 
@@ -68,9 +58,28 @@ class AuthRouter {
           .get()
           .timeout(const Duration(seconds: 5));
 
-      final isComplete = doc.exists &&
-          doc.data() != null &&
-          ProfileCompletionGuard.isDocumentComplete(doc.data()!);
+      final profileData = doc.data();
+      if (!doc.exists || profileData == null) {
+        log(
+          'AuthRouter: authenticated session has no user profile document '
+          '— signing out and returning to welcome',
+        );
+        if (!context.mounted) return;
+        await _signOutAndGoWelcome(context);
+        return;
+      }
+
+      final isComplete = ProfileCompletionGuard.isDocumentComplete(profileData);
+
+      if (!isComplete && _isBlankProfile(profileData)) {
+        log(
+          'AuthRouter: blank/incomplete profile detected '
+          '— signing out and returning to welcome',
+        );
+        if (!context.mounted) return;
+        await _signOutAndGoWelcome(context);
+        return;
+      }
 
       if (!context.mounted) return;
 
@@ -117,5 +126,42 @@ class AuthRouter {
     if (providerIds.isEmpty) return true;
 
     return !providerIds.any(_supportedProviderIds.contains);
+  }
+
+  static bool _isBlankProfile(Map<String, dynamic> data) {
+    bool isNonEmptyString(Object? value) =>
+        value is String && value.trim().isNotEmpty;
+    bool hasNonEmptyList(String key) =>
+        data[key] is List && (data[key] as List).isNotEmpty;
+
+    final hasName =
+        isNonEmptyString(data['name']) || isNonEmptyString(data['userName']);
+    final hasGender = isNonEmptyString(data['gender']) ||
+        isNonEmptyString(data['userGender']);
+    final hasBio = isNonEmptyString(data['bio']);
+    final hasPhoto = hasNonEmptyList('photos') ||
+        hasNonEmptyList('Pictures') ||
+        hasNonEmptyList('imageUrl') ||
+        isNonEmptyString(data['profilePicture']);
+    final hasLocation = isNonEmptyString(data['locationName']) ||
+        (data['location'] is Map &&
+            isNonEmptyString((data['location'] as Map)['address']));
+
+    return !(hasName || hasGender || hasPhoto || hasBio || hasLocation);
+  }
+
+  static Future<void> _signOutAndGoWelcome(BuildContext context) async {
+    try {
+      await FirebaseAuth.instance.signOut();
+    } on Object catch (e) {
+      log('AuthRouter: signOut failed while clearing session: $e');
+    }
+
+    if (context.mounted) {
+      await Navigator.of(context).pushNamedAndRemoveUntil(
+        RouteName.welcomeScreen,
+        (route) => false,
+      );
+    }
   }
 }

--- a/lib/features/onboarding/bloc/onboarding_bloc.dart
+++ b/lib/features/onboarding/bloc/onboarding_bloc.dart
@@ -544,6 +544,19 @@ class OnboardingBloc extends Bloc<OnboardingEvent, OnboardingState> {
     } on Object catch (err) {
       log('Error saving user data: $err');
       emit(OnboardingSaveFailure(err.toString()));
+      if (context != null && context.mounted) {
+        final navigator = Navigator.of(context, rootNavigator: true);
+        if (navigator.canPop()) {
+          navigator.pop();
+        }
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'Could not complete profile setup. Please try again.',
+            ),
+          ),
+        );
+      }
       // Do not navigate to main app on failure; user stays on onboarding to retry.
     }
   }

--- a/lib/features/onboarding/data/repositories/onboarding_repository.dart
+++ b/lib/features/onboarding/data/repositories/onboarding_repository.dart
@@ -15,16 +15,21 @@ class OnboardingRepository {
     required OnboardingData data,
     required String userId,
   }) async {
+    final userRef = FirebaseFirestore.instance.collection('users').doc(userId);
     final essentialData = _buildEssentialData(data);
 
     AppLogger.info('🔍 Saving essential user data to Firestore...');
 
-    await FirebaseFirestore.instance
-        .collection('users')
-        .doc(userId)
-        .set(essentialData, SetOptions(merge: true));
+    // Firestore rules lock `createdAt` after initial creation.
+    // Keep it only on first write; never attempt to mutate it later.
+    final snapshot = await userRef.get();
+    if (snapshot.exists) {
+      essentialData.remove('createdAt');
+    }
 
-    await FirebaseFirestore.instance.collection('users').doc(userId).update({
+    await userRef.set(essentialData, SetOptions(merge: true));
+
+    await userRef.update({
       'updatedAt': FieldValue.serverTimestamp(),
     });
 


### PR DESCRIPTION
## Summary
Two bugs fixed that caused the "Setting up your profile..." infinite spinner and stale sessions routing into onboarding.

## Bug 1: Endless "Setting up your profile..." spinner
- **Root cause:** `OnboardingRepository.saveUserData()` always wrote `createdAt`, but Firestore rules block `createdAt` updates on existing user docs. The write threw, and the loading overlay was never dismissed.
- **Fix (onboarding_repository.dart):** Check if doc exists before writing; strip `createdAt` on existing docs.
- **Fix (onboarding_bloc.dart):** On save failure, dismiss loading overlay (`navigator.pop()`) and show error snackbar so user can retry.

## Bug 2: Ghost sessions routing into onboarding
- **Root cause:** Stale Firebase sessions (e.g. carried-over TestFlight credentials) with missing or blank profile docs would pass the session check and route into onboarding instead of showing Welcome.
- **Fix (auth_router.dart):** Sign out and go to Welcome for sessions with no profile doc or blank profile data (no name, gender, photo, bio, or location). Extracted `_signOutAndGoWelcome` helper and added `_isBlankProfile` check.

## Test plan
- [x] `flutter test` on auth and onboarding test suite — all passed
- [x] `flutter analyze` on changed files — no issues

Made with [Cursor](https://cursor.com)