### PR TITLE
fix(auth,onboarding): Firestore identity lock, resilient saves, empty view overflow

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -22,15 +22,14 @@ service cloud.firestore {
              );
     }
 
-    // Canonical flag: onboardingCompleted.  Legacy synonyms
-    // (profileSetupComplete, isProfileComplete) are kept for backward
-    // compatibility with documents created before flag names were unified.
-    // All new writes must set onboardingCompleted; the OR ensures existing
-    // documents still trigger the identity lock.
+    // Identity lock: only when the canonical onboarding flag is true.
+    // Do not OR in profileSetupComplete / isProfileComplete here: legacy
+    // documents sometimes have those set without onboardingCompleted, which
+    // blocked legitimate first-time onboarding writes (permission-denied).
+    // Users who only have legacy flags without onboardingCompleted are
+    // uncommon; backfill onboardingCompleted if you need the same lock.
     function isLockedIdentityFieldUpdate() {
-      return (resource.data.onboardingCompleted == true ||
-              resource.data.profileSetupComplete == true ||
-              resource.data.isProfileComplete == true) &&
+      return resource.data.onboardingCompleted == true &&
              (
                request.resource.data.name != resource.data.name ||
                request.resource.data.dateOfBirth != resource.data.dateOfBirth

--- a/lib/common/data/repo/googlelogin_repo.dart
+++ b/lib/common/data/repo/googlelogin_repo.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
@@ -59,26 +61,42 @@ class GoogleLoginRepositoryImpl implements GoogleLoginRepository {
   @override
   Future<void> ensureUserDocument(User user) async {
     final userRef = firebaseFireStoreInstance.collection('users').doc(user.uid);
-    final doc = await userRef.get();
-    if (doc.exists && doc.data() != null && doc.data()!.isNotEmpty) {
-      // Keep existing docs updates limited to mutable fields.
-      // Firestore rules block updates to `email` and can lock `name`
-      // after onboarding completion.
-      await userRef.update({
-        'lastActive': FieldValue.serverTimestamp(),
-        'lastSignIn': FieldValue.serverTimestamp(),
-        'photoUrl': user.photoURL ?? '',
-      });
-    } else {
-      await userRef.set({
-        'email': user.email,
-        'name': user.displayName,
-        'photoUrl': user.photoURL,
-        'createdAt': FieldValue.serverTimestamp(),
-        'lastActive': FieldValue.serverTimestamp(),
-        'signInMethod': 'google',
-        'onboardingCompleted': false,
-      });
+
+    Future<void> upsert() async {
+      final doc = await userRef.get();
+      if (doc.exists && doc.data() != null && doc.data()!.isNotEmpty) {
+        // Keep existing docs updates limited to mutable fields.
+        // Firestore rules block updates to `email` and can lock `name`
+        // after onboarding completion.
+        await userRef.update({
+          'lastActive': FieldValue.serverTimestamp(),
+          'lastSignIn': FieldValue.serverTimestamp(),
+          'photoUrl': user.photoURL ?? '',
+        });
+      } else {
+        await userRef.set({
+          'email': user.email,
+          'name': user.displayName,
+          'photoUrl': user.photoURL,
+          'createdAt': FieldValue.serverTimestamp(),
+          'lastActive': FieldValue.serverTimestamp(),
+          'signInMethod': 'google',
+          'onboardingCompleted': false,
+        });
+      }
+    }
+
+    try {
+      // Reduce transient auth propagation race right after sign-in.
+      await user.getIdToken(true);
+      await upsert();
+    } on FirebaseException catch (e) {
+      if (e.code != 'permission-denied') rethrow;
+
+      // Retry once after token refresh + short delay.
+      await user.getIdToken(true);
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+      await upsert();
     }
   }
 

--- a/lib/common/widgets/state_views/app_empty_view.dart
+++ b/lib/common/widgets/state_views/app_empty_view.dart
@@ -25,9 +25,10 @@ class AppEmptyView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Center(
-        child: Padding(
+        child: SingleChildScrollView(
           padding: const EdgeInsets.all(AppSpacing.xl),
           child: Column(
+            mainAxisSize: MainAxisSize.min,
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               Icon(

--- a/lib/features/auth/email_password/ui/screens/email_login_screen.dart
+++ b/lib/features/auth/email_password/ui/screens/email_login_screen.dart
@@ -68,9 +68,9 @@ class _EmailLoginScreenState extends State<EmailLoginScreen> {
           builder: (context, state) => SafeArea(
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 24),
-              child: Center(
-                child: SingleChildScrollView(
-                  child: Form(
+              child: SingleChildScrollView(
+                keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+                child: Form(
                     key: _formKey,
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
@@ -246,7 +246,6 @@ class _EmailLoginScreenState extends State<EmailLoginScreen> {
                       ],
                     ),
                   ),
-                ),
               ),
             ),
           ),

--- a/lib/features/auth/email_password/ui/screens/email_login_screen.dart
+++ b/lib/features/auth/email_password/ui/screens/email_login_screen.dart
@@ -69,183 +69,184 @@ class _EmailLoginScreenState extends State<EmailLoginScreen> {
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 24),
               child: SingleChildScrollView(
-                keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+                keyboardDismissBehavior:
+                    ScrollViewKeyboardDismissBehavior.onDrag,
                 child: Form(
-                    key: _formKey,
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        // Email icon using reusable widget
-                        const AuthIconContainer(
-                          icon: Icons.email_outlined,
+                  key: _formKey,
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      // Email icon using reusable widget
+                      const AuthIconContainer(
+                        icon: Icons.email_outlined,
+                      ),
+
+                      const SizedBox(height: 32),
+
+                      // Header
+                      Text(
+                        'Welcome Back',
+                        style: GoogleFonts.montserrat(
+                          fontSize: 24,
+                          fontWeight: FontWeight.w600,
+                          color: AppColors.primaryGreen,
                         ),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        'Sign in to continue',
+                        style: GoogleFonts.montserrat(
+                          fontSize: 16,
+                          color: AppColors.textSecondary,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 40),
 
-                        const SizedBox(height: 32),
+                      // Email field using reusable widget
+                      AfropeepTextField(
+                        controller: _emailController,
+                        hintText: 'Email',
+                        prefixIcon: Icons.email_outlined,
+                        keyboardType: TextInputType.emailAddress,
+                        onChanged: () => setState(() {}),
+                        validationChecker: (text) =>
+                            RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$')
+                                .hasMatch(text),
+                        validator: (value) {
+                          if (value == null || value.isEmpty) {
+                            return 'Please enter your email';
+                          }
+                          if (!RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$')
+                              .hasMatch(value)) {
+                            return 'Please enter a valid email address';
+                          }
+                          return null;
+                        },
+                      ),
+                      const SizedBox(height: 20),
 
-                        // Header
-                        Text(
-                          'Welcome Back',
-                          style: GoogleFonts.montserrat(
-                            fontSize: 24,
-                            fontWeight: FontWeight.w600,
-                            color: AppColors.primaryGreen,
+                      // Password field using reusable widget
+                      AfropeepTextField(
+                        controller: _passwordController,
+                        hintText: 'Password',
+                        prefixIcon: Icons.lock_outline,
+                        obscureText: _obscurePassword,
+                        onChanged: () => setState(() {}),
+                        suffixIcon: IconButton(
+                          icon: Icon(
+                            _obscurePassword
+                                ? Icons.visibility_off
+                                : Icons.visibility,
+                            color: Colors.grey.shade600,
                           ),
-                          textAlign: TextAlign.center,
-                        ),
-                        const SizedBox(height: 12),
-                        Text(
-                          'Sign in to continue',
-                          style: GoogleFonts.montserrat(
-                            fontSize: 16,
-                            color: AppColors.textSecondary,
-                          ),
-                          textAlign: TextAlign.center,
-                        ),
-                        const SizedBox(height: 40),
-
-                        // Email field using reusable widget
-                        AfropeepTextField(
-                          controller: _emailController,
-                          hintText: 'Email',
-                          prefixIcon: Icons.email_outlined,
-                          keyboardType: TextInputType.emailAddress,
-                          onChanged: () => setState(() {}),
-                          validationChecker: (text) =>
-                              RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$')
-                                  .hasMatch(text),
-                          validator: (value) {
-                            if (value == null || value.isEmpty) {
-                              return 'Please enter your email';
-                            }
-                            if (!RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$')
-                                .hasMatch(value)) {
-                              return 'Please enter a valid email address';
-                            }
-                            return null;
+                          onPressed: () {
+                            setState(() {
+                              _obscurePassword = !_obscurePassword;
+                            });
                           },
                         ),
-                        const SizedBox(height: 20),
+                        validator: (value) {
+                          if (value == null || value.isEmpty) {
+                            return 'Please enter your password';
+                          }
+                          return null;
+                        },
+                      ),
 
-                        // Password field using reusable widget
-                        AfropeepTextField(
-                          controller: _passwordController,
-                          hintText: 'Password',
-                          prefixIcon: Icons.lock_outline,
-                          obscureText: _obscurePassword,
-                          onChanged: () => setState(() {}),
-                          suffixIcon: IconButton(
-                            icon: Icon(
-                              _obscurePassword
-                                  ? Icons.visibility_off
-                                  : Icons.visibility,
-                              color: Colors.grey.shade600,
+                      const SizedBox(height: 16),
+
+                      // Forgot password
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: TextButton(
+                          onPressed: () {
+                            unawaited(
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder: (context) =>
+                                      const EmailPasswordResetScreen(),
+                                ),
+                              ),
+                            );
+                          },
+                          style: TextButton.styleFrom(
+                            foregroundColor: AppColors.primaryGreen,
+                            padding: EdgeInsets.zero,
+                            minimumSize: const Size(0, 36),
+                            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                          ),
+                          child: Text(
+                            'Forgot Password?',
+                            style: GoogleFonts.montserrat(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w500,
                             ),
-                            onPressed: () {
-                              setState(() {
-                                _obscurePassword = !_obscurePassword;
-                              });
-                            },
                           ),
-                          validator: (value) {
-                            if (value == null || value.isEmpty) {
-                              return 'Please enter your password';
-                            }
-                            return null;
-                          },
                         ),
+                      ),
 
-                        const SizedBox(height: 16),
+                      const SizedBox(height: 40),
 
-                        // Forgot password
-                        Align(
-                          alignment: Alignment.centerRight,
-                          child: TextButton(
-                            onPressed: () {
+                      // Sign In Button using reusable widget
+                      AfropeepPrimaryButton(
+                        text: 'Sign In',
+                        isLoading: state is EmailAuthLoading,
+                        onPressed: () {
+                          if (_formKey.currentState!.validate()) {
+                            context.read<EmailAuthBloc>().add(
+                                  EmailSignInRequested(
+                                    email: _emailController.text.trim(),
+                                    password: _passwordController.text,
+                                  ),
+                                );
+                          }
+                        },
+                      ),
+
+                      const SizedBox(height: 40),
+
+                      // Don't have an account? Sign up
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text(
+                            "Don't have an account? ",
+                            style: GoogleFonts.montserrat(
+                              fontSize: 14,
+                              color: AppColors.textPrimary,
+                            ),
+                          ),
+                          GestureDetector(
+                            onTap: () {
                               unawaited(
                                 Navigator.push(
                                   context,
                                   MaterialPageRoute(
                                     builder: (context) =>
-                                        const EmailPasswordResetScreen(),
+                                        const AuthMethodSelectionScreen(),
                                   ),
                                 ),
                               );
                             },
-                            style: TextButton.styleFrom(
-                              foregroundColor: AppColors.primaryGreen,
-                              padding: EdgeInsets.zero,
-                              minimumSize: const Size(0, 36),
-                              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                            ),
                             child: Text(
-                              'Forgot Password?',
+                              'Sign Up',
                               style: GoogleFonts.montserrat(
                                 fontSize: 14,
-                                fontWeight: FontWeight.w500,
+                                fontWeight: FontWeight.w600,
+                                color: AppColors.primaryGreen,
                               ),
                             ),
                           ),
-                        ),
+                        ],
+                      ),
 
-                        const SizedBox(height: 40),
-
-                        // Sign In Button using reusable widget
-                        AfropeepPrimaryButton(
-                          text: 'Sign In',
-                          isLoading: state is EmailAuthLoading,
-                          onPressed: () {
-                            if (_formKey.currentState!.validate()) {
-                              context.read<EmailAuthBloc>().add(
-                                    EmailSignInRequested(
-                                      email: _emailController.text.trim(),
-                                      password: _passwordController.text,
-                                    ),
-                                  );
-                            }
-                          },
-                        ),
-
-                        const SizedBox(height: 40),
-
-                        // Don't have an account? Sign up
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Text(
-                              "Don't have an account? ",
-                              style: GoogleFonts.montserrat(
-                                fontSize: 14,
-                                color: AppColors.textPrimary,
-                              ),
-                            ),
-                            GestureDetector(
-                              onTap: () {
-                                unawaited(
-                                  Navigator.push(
-                                    context,
-                                    MaterialPageRoute(
-                                      builder: (context) =>
-                                          const AuthMethodSelectionScreen(),
-                                    ),
-                                  ),
-                                );
-                              },
-                              child: Text(
-                                'Sign Up',
-                                style: GoogleFonts.montserrat(
-                                  fontSize: 14,
-                                  fontWeight: FontWeight.w600,
-                                  color: AppColors.primaryGreen,
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-
-                        const SizedBox(height: 24),
-                      ],
-                    ),
+                      const SizedBox(height: 24),
+                    ],
                   ),
+                ),
               ),
             ),
           ),

--- a/lib/features/auth/email_password/ui/screens/email_password_reset_screen.dart
+++ b/lib/features/auth/email_password/ui/screens/email_password_reset_screen.dart
@@ -66,98 +66,99 @@ class _EmailPasswordResetScreenState extends State<EmailPasswordResetScreen> {
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 24),
               child: SingleChildScrollView(
-                keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+                keyboardDismissBehavior:
+                    ScrollViewKeyboardDismissBehavior.onDrag,
                 child: Form(
-                    key: _formKey,
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        // Lock reset icon using reusable widget
-                        const AuthIconContainer(
-                          icon: Icons.lock_reset_outlined,
-                        ),
+                  key: _formKey,
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      // Lock reset icon using reusable widget
+                      const AuthIconContainer(
+                        icon: Icons.lock_reset_outlined,
+                      ),
 
-                        const SizedBox(height: 32),
+                      const SizedBox(height: 32),
 
-                        // Header
-                        Text(
-                          'Forgot Your Password?',
-                          style: GoogleFonts.montserrat(
-                            fontSize: 24,
-                            fontWeight: FontWeight.w600,
-                            color: AppColors.primaryGreen,
-                          ),
-                          textAlign: TextAlign.center,
+                      // Header
+                      Text(
+                        'Forgot Your Password?',
+                        style: GoogleFonts.montserrat(
+                          fontSize: 24,
+                          fontWeight: FontWeight.w600,
+                          color: AppColors.primaryGreen,
                         ),
-                        const SizedBox(height: 12),
-                        Text(
-                          'Enter your email address and we\'ll send you a link to reset your password',
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        'Enter your email address and we\'ll send you a link to reset your password',
+                        style: GoogleFonts.montserrat(
+                          fontSize: 16,
+                          color: AppColors.textSecondary,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 40),
+
+                      // Email Field using reusable widget
+                      AfropeepTextField(
+                        controller: _emailController,
+                        hintText: 'Email',
+                        prefixIcon: Icons.email_outlined,
+                        keyboardType: TextInputType.emailAddress,
+                        onChanged: () => setState(() {}),
+                        validationChecker: (text) =>
+                            RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$')
+                                .hasMatch(text),
+                        validator: (value) {
+                          if (value == null || value.isEmpty) {
+                            return 'Please enter your email';
+                          }
+                          if (!RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$')
+                              .hasMatch(value)) {
+                            return 'Please enter a valid email address';
+                          }
+                          return null;
+                        },
+                      ),
+
+                      const SizedBox(height: 40),
+
+                      // Send Reset Link Button using reusable widget
+                      AfropeepPrimaryButton(
+                        text: 'Send Reset Link',
+                        isLoading: state is EmailAuthLoading,
+                        onPressed: () {
+                          if (_formKey.currentState!.validate()) {
+                            context.read<EmailAuthBloc>().add(
+                                  EmailPasswordResetRequested(
+                                    email: _emailController.text.trim(),
+                                  ),
+                                );
+                          }
+                        },
+                      ),
+
+                      const SizedBox(height: 24),
+
+                      // Back to Login
+                      TextButton(
+                        onPressed: () {
+                          Navigator.pop(context);
+                        },
+                        child: Text(
+                          'Back to Login',
                           style: GoogleFonts.montserrat(
-                            fontSize: 16,
+                            fontSize: 14,
+                            fontWeight: FontWeight.w500,
                             color: AppColors.textSecondary,
                           ),
-                          textAlign: TextAlign.center,
                         ),
-                        const SizedBox(height: 40),
-
-                        // Email Field using reusable widget
-                        AfropeepTextField(
-                          controller: _emailController,
-                          hintText: 'Email',
-                          prefixIcon: Icons.email_outlined,
-                          keyboardType: TextInputType.emailAddress,
-                          onChanged: () => setState(() {}),
-                          validationChecker: (text) =>
-                              RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$')
-                                  .hasMatch(text),
-                          validator: (value) {
-                            if (value == null || value.isEmpty) {
-                              return 'Please enter your email';
-                            }
-                            if (!RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$')
-                                .hasMatch(value)) {
-                              return 'Please enter a valid email address';
-                            }
-                            return null;
-                          },
-                        ),
-
-                        const SizedBox(height: 40),
-
-                        // Send Reset Link Button using reusable widget
-                        AfropeepPrimaryButton(
-                          text: 'Send Reset Link',
-                          isLoading: state is EmailAuthLoading,
-                          onPressed: () {
-                            if (_formKey.currentState!.validate()) {
-                              context.read<EmailAuthBloc>().add(
-                                    EmailPasswordResetRequested(
-                                      email: _emailController.text.trim(),
-                                    ),
-                                  );
-                            }
-                          },
-                        ),
-
-                        const SizedBox(height: 24),
-
-                        // Back to Login
-                        TextButton(
-                          onPressed: () {
-                            Navigator.pop(context);
-                          },
-                          child: Text(
-                            'Back to Login',
-                            style: GoogleFonts.montserrat(
-                              fontSize: 14,
-                              fontWeight: FontWeight.w500,
-                              color: AppColors.textSecondary,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
+                      ),
+                    ],
                   ),
+                ),
               ),
             ),
           ),

--- a/lib/features/auth/email_password/ui/screens/email_password_reset_screen.dart
+++ b/lib/features/auth/email_password/ui/screens/email_password_reset_screen.dart
@@ -65,9 +65,9 @@ class _EmailPasswordResetScreenState extends State<EmailPasswordResetScreen> {
           builder: (context, state) => SafeArea(
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 24),
-              child: Center(
-                child: SingleChildScrollView(
-                  child: Form(
+              child: SingleChildScrollView(
+                keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+                child: Form(
                     key: _formKey,
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
@@ -158,7 +158,6 @@ class _EmailPasswordResetScreenState extends State<EmailPasswordResetScreen> {
                       ],
                     ),
                   ),
-                ),
               ),
             ),
           ),

--- a/lib/features/auth/email_password/ui/screens/email_signup_screen.dart
+++ b/lib/features/auth/email_password/ui/screens/email_signup_screen.dart
@@ -60,9 +60,10 @@ class _EmailSignupScreenState extends State<EmailSignupScreen> {
             builder: (context, state) => SafeArea(
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 24),
-                child: Center(
-                  child: SingleChildScrollView(
-                    child: Form(
+                child: SingleChildScrollView(
+                  keyboardDismissBehavior:
+                      ScrollViewKeyboardDismissBehavior.onDrag,
+                  child: Form(
                       key: _formKey,
                       child: Column(
                         mainAxisAlignment: MainAxisAlignment.center,
@@ -239,7 +240,6 @@ class _EmailSignupScreenState extends State<EmailSignupScreen> {
                         ],
                       ),
                     ),
-                  ),
                 ),
               ),
             ),

--- a/lib/features/auth/email_password/ui/screens/email_signup_screen.dart
+++ b/lib/features/auth/email_password/ui/screens/email_signup_screen.dart
@@ -64,182 +64,182 @@ class _EmailSignupScreenState extends State<EmailSignupScreen> {
                   keyboardDismissBehavior:
                       ScrollViewKeyboardDismissBehavior.onDrag,
                   child: Form(
-                      key: _formKey,
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          // Email icon using reusable widget
-                          const AuthIconContainer(
-                            icon: Icons.email_outlined,
+                    key: _formKey,
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        // Email icon using reusable widget
+                        const AuthIconContainer(
+                          icon: Icons.email_outlined,
+                        ),
+
+                        const SizedBox(height: 32),
+
+                        // Header
+                        Text(
+                          'Sign up with Email',
+                          style: GoogleFonts.montserrat(
+                            fontSize: 24,
+                            fontWeight: FontWeight.w600,
+                            color: AppColors.primaryGreen,
                           ),
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(height: 12),
+                        Text(
+                          'Enter your email and create a password to get started',
+                          style: GoogleFonts.montserrat(
+                            fontSize: 16,
+                            color: AppColors.textSecondary,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(height: 40),
 
-                          const SizedBox(height: 32),
+                        // Email field using reusable widget
+                        AfropeepTextField(
+                          controller: _emailController,
+                          hintText: 'Email',
+                          prefixIcon: Icons.email_outlined,
+                          keyboardType: TextInputType.emailAddress,
+                          onChanged: () => setState(() {}),
+                          validationChecker: (text) =>
+                              RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$')
+                                  .hasMatch(text),
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return 'Please enter your email';
+                            }
+                            if (!RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$')
+                                .hasMatch(value)) {
+                              return 'Please enter a valid email address';
+                            }
+                            return null;
+                          },
+                        ),
+                        const SizedBox(height: 20),
 
-                          // Header
-                          Text(
-                            'Sign up with Email',
-                            style: GoogleFonts.montserrat(
-                              fontSize: 24,
-                              fontWeight: FontWeight.w600,
-                              color: AppColors.primaryGreen,
+                        // Password field using reusable widget
+                        AfropeepTextField(
+                          controller: _passwordController,
+                          hintText: 'Password',
+                          prefixIcon: Icons.lock_outline,
+                          obscureText: _obscurePassword,
+                          onChanged: () => setState(() {}),
+                          validationChecker: (text) => text.length >= 6,
+                          suffixIcon: IconButton(
+                            icon: Icon(
+                              _obscurePassword
+                                  ? Icons.visibility_off
+                                  : Icons.visibility,
+                              color: Colors.grey.shade600,
                             ),
-                            textAlign: TextAlign.center,
-                          ),
-                          const SizedBox(height: 12),
-                          Text(
-                            'Enter your email and create a password to get started',
-                            style: GoogleFonts.montserrat(
-                              fontSize: 16,
-                              color: AppColors.textSecondary,
-                            ),
-                            textAlign: TextAlign.center,
-                          ),
-                          const SizedBox(height: 40),
-
-                          // Email field using reusable widget
-                          AfropeepTextField(
-                            controller: _emailController,
-                            hintText: 'Email',
-                            prefixIcon: Icons.email_outlined,
-                            keyboardType: TextInputType.emailAddress,
-                            onChanged: () => setState(() {}),
-                            validationChecker: (text) =>
-                                RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$')
-                                    .hasMatch(text),
-                            validator: (value) {
-                              if (value == null || value.isEmpty) {
-                                return 'Please enter your email';
-                              }
-                              if (!RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$')
-                                  .hasMatch(value)) {
-                                return 'Please enter a valid email address';
-                              }
-                              return null;
-                            },
-                          ),
-                          const SizedBox(height: 20),
-
-                          // Password field using reusable widget
-                          AfropeepTextField(
-                            controller: _passwordController,
-                            hintText: 'Password',
-                            prefixIcon: Icons.lock_outline,
-                            obscureText: _obscurePassword,
-                            onChanged: () => setState(() {}),
-                            validationChecker: (text) => text.length >= 6,
-                            suffixIcon: IconButton(
-                              icon: Icon(
-                                _obscurePassword
-                                    ? Icons.visibility_off
-                                    : Icons.visibility,
-                                color: Colors.grey.shade600,
-                              ),
-                              onPressed: () {
-                                setState(() {
-                                  _obscurePassword = !_obscurePassword;
-                                });
-                              },
-                            ),
-                            validator: (value) {
-                              if (value == null || value.isEmpty) {
-                                return 'Please enter a password';
-                              }
-                              if (value.length < 6) {
-                                return 'Password must be at least 6 characters';
-                              }
-                              return null;
-                            },
-                          ),
-                          const SizedBox(height: 20),
-
-                          // Confirm Password Field using reusable widget
-                          AfropeepTextField(
-                            controller: _confirmPasswordController,
-                            hintText: 'Confirm Password',
-                            prefixIcon: Icons.lock_outline,
-                            obscureText: _obscureConfirmPassword,
-                            onChanged: () => setState(() {}),
-                            validationChecker: (text) =>
-                                text == _passwordController.text &&
-                                text.isNotEmpty,
-                            suffixIcon: IconButton(
-                              icon: Icon(
-                                _obscureConfirmPassword
-                                    ? Icons.visibility_off
-                                    : Icons.visibility,
-                                color: Colors.grey.shade600,
-                              ),
-                              onPressed: () {
-                                setState(() {
-                                  _obscureConfirmPassword =
-                                      !_obscureConfirmPassword;
-                                });
-                              },
-                            ),
-                            validator: (value) {
-                              if (value == null || value.isEmpty) {
-                                return 'Please confirm your password';
-                              }
-                              if (value != _passwordController.text) {
-                                return 'Passwords do not match';
-                              }
-                              return null;
-                            },
-                          ),
-                          const SizedBox(height: 40),
-
-                          // Create Account Button using reusable widget
-                          AfropeepPrimaryButton(
-                            text: 'Create Account',
-                            isLoading: state is EmailAuthLoading,
                             onPressed: () {
-                              if (_formKey.currentState!.validate()) {
-                                context.read<EmailAuthBloc>().add(
-                                      EmailSignUpRequested(
-                                        email: _emailController.text.trim(),
-                                        password: _passwordController.text,
-                                      ),
-                                    );
-                              }
+                              setState(() {
+                                _obscurePassword = !_obscurePassword;
+                              });
                             },
                           ),
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return 'Please enter a password';
+                            }
+                            if (value.length < 6) {
+                              return 'Password must be at least 6 characters';
+                            }
+                            return null;
+                          },
+                        ),
+                        const SizedBox(height: 20),
 
-                          const SizedBox(height: 40),
+                        // Confirm Password Field using reusable widget
+                        AfropeepTextField(
+                          controller: _confirmPasswordController,
+                          hintText: 'Confirm Password',
+                          prefixIcon: Icons.lock_outline,
+                          obscureText: _obscureConfirmPassword,
+                          onChanged: () => setState(() {}),
+                          validationChecker: (text) =>
+                              text == _passwordController.text &&
+                              text.isNotEmpty,
+                          suffixIcon: IconButton(
+                            icon: Icon(
+                              _obscureConfirmPassword
+                                  ? Icons.visibility_off
+                                  : Icons.visibility,
+                              color: Colors.grey.shade600,
+                            ),
+                            onPressed: () {
+                              setState(() {
+                                _obscureConfirmPassword =
+                                    !_obscureConfirmPassword;
+                              });
+                            },
+                          ),
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return 'Please confirm your password';
+                            }
+                            if (value != _passwordController.text) {
+                              return 'Passwords do not match';
+                            }
+                            return null;
+                          },
+                        ),
+                        const SizedBox(height: 40),
 
-                          // Already have an account
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Text(
-                                'Already have an account? ',
-                                style: GoogleFonts.montserrat(
-                                  fontSize: 14,
-                                  color: AppColors.textPrimary,
-                                ),
-                              ),
-                              GestureDetector(
-                                onTap: () {
-                                  unawaited(
-                                    Navigator.pushReplacementNamed(
-                                      context,
-                                      '/email_login',
+                        // Create Account Button using reusable widget
+                        AfropeepPrimaryButton(
+                          text: 'Create Account',
+                          isLoading: state is EmailAuthLoading,
+                          onPressed: () {
+                            if (_formKey.currentState!.validate()) {
+                              context.read<EmailAuthBloc>().add(
+                                    EmailSignUpRequested(
+                                      email: _emailController.text.trim(),
+                                      password: _passwordController.text,
                                     ),
                                   );
-                                },
-                                child: Text(
-                                  'Log In',
-                                  style: GoogleFonts.montserrat(
-                                    fontSize: 14,
-                                    fontWeight: FontWeight.w600,
-                                    color: AppColors.primaryGreen,
+                            }
+                          },
+                        ),
+
+                        const SizedBox(height: 40),
+
+                        // Already have an account
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Text(
+                              'Already have an account? ',
+                              style: GoogleFonts.montserrat(
+                                fontSize: 14,
+                                color: AppColors.textPrimary,
+                              ),
+                            ),
+                            GestureDetector(
+                              onTap: () {
+                                unawaited(
+                                  Navigator.pushReplacementNamed(
+                                    context,
+                                    '/email_login',
                                   ),
+                                );
+                              },
+                              child: Text(
+                                'Log In',
+                                style: GoogleFonts.montserrat(
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.w600,
+                                  color: AppColors.primaryGreen,
                                 ),
                               ),
-                            ],
-                          ),
-                        ],
-                      ),
+                            ),
+                          ],
+                        ),
+                      ],
                     ),
+                  ),
                 ),
               ),
             ),

--- a/lib/features/auth/google_login/google_login_bloc.dart
+++ b/lib/features/auth/google_login/google_login_bloc.dart
@@ -34,7 +34,20 @@ class GoogleLoginBloc extends Bloc<GoogleLoginEvents, GoogleLoginStates> {
         return;
       }
       log('Google sign-in successful: ${user.displayName}');
-      await _repository.ensureUserDocument(user);
+      try {
+        await _repository.ensureUserDocument(user);
+      } on FirebaseException catch (e) {
+        if (e.code == 'permission-denied') {
+          // Do not block authenticated users from entering the app when
+          // profile reconciliation is denied by rules or transient auth races.
+          log(
+            'Google profile reconciliation denied by Firestore rules; '
+            'continuing with authenticated session',
+          );
+        } else {
+          rethrow;
+        }
+      }
       emit(GoogleLoginSuccess(user: user));
     } on SocketException {
       log('Google sign-in failed: No Internet Connection');

--- a/lib/features/auth/phone/ui/screens/phone_login.dart
+++ b/lib/features/auth/phone/ui/screens/phone_login.dart
@@ -100,9 +100,9 @@ class _PhoneNumberState extends State<PhoneNumber> {
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 24),
-          child: Center(
-            child: SingleChildScrollView(
-              child: Column(
+          child: SingleChildScrollView(
+            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+            child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   // Phone icon with Afrocentric style
@@ -307,7 +307,6 @@ class _PhoneNumberState extends State<PhoneNumber> {
                   const SizedBox(height: 24),
                 ],
               ),
-            ),
           ),
         ),
       ),

--- a/lib/features/auth/phone/ui/screens/phone_login.dart
+++ b/lib/features/auth/phone/ui/screens/phone_login.dart
@@ -103,210 +103,210 @@ class _PhoneNumberState extends State<PhoneNumber> {
           child: SingleChildScrollView(
             keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
             child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  // Phone icon with Afrocentric style
-                  Container(
-                    width: 100,
-                    height: 100,
-                    decoration: BoxDecoration(
-                      color: iconBackgroundColor,
-                      shape: BoxShape.circle,
-                      boxShadow: [
-                        BoxShadow(
-                          color: primaryColor.withValues(alpha: 0.2),
-                          blurRadius: 15,
-                          offset: const Offset(0, 5),
-                        ),
-                      ],
-                    ),
-                    child: const Icon(
-                      Icons.phone_android,
-                      color: primaryColor,
-                      size: 50,
-                    ),
-                  ),
-
-                  const SizedBox(height: 32),
-
-                  Text(
-                    'Enter your phone number',
-                    style: GoogleFonts.montserrat(
-                      fontSize: 24,
-                      fontWeight: FontWeight.w600,
-                      color: primaryColor,
-                    ),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 12),
-                  Text(
-                    "We'll send you a verification code",
-                    style: GoogleFonts.montserrat(
-                      fontSize: 16,
-                      color: subtextColor,
-                    ),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 40),
-
-                  // Phone number input with country code
-                  DecoratedBox(
-                    decoration: BoxDecoration(
-                      color: Colors.white,
-                      borderRadius: BorderRadius.circular(16),
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.black.withValues(alpha: 0.05),
-                          blurRadius: 10,
-                          offset: const Offset(0, 5),
-                        ),
-                      ],
-                    ),
-                    child: Row(
-                      children: [
-                        // Country code dropdown
-                        Container(
-                          padding: const EdgeInsets.symmetric(horizontal: 16),
-                          decoration: BoxDecoration(
-                            border: Border(
-                              right: BorderSide(
-                                color: Colors.grey.withValues(alpha: 0.3),
-                              ),
-                            ),
-                          ),
-                          child: DropdownButton<String>(
-                            value: _selectedCountryCode,
-                            icon: const Icon(Icons.arrow_drop_down),
-                            elevation: 16,
-                            style: GoogleFonts.montserrat(
-                              fontSize: 16,
-                              color: textColor,
-                            ),
-                            underline: Container(
-                              height: 0,
-                            ),
-                            onChanged: (String? newValue) {
-                              setState(() {
-                                _selectedCountryCode = newValue!;
-                              });
-                            },
-                            items: _countryCodes
-                                .map<DropdownMenuItem<String>>(
-                                  (Map<String, String> value) =>
-                                      DropdownMenuItem<String>(
-                                    value: value['code'],
-                                    child: Text(
-                                      "${value['code']} (${value['name']})",
-                                    ),
-                                  ),
-                                )
-                                .toList(),
-                          ),
-                        ),
-
-                        // Phone number input
-                        Expanded(
-                          child: TextField(
-                            controller: _phoneController,
-                            keyboardType: TextInputType.phone,
-                            style: GoogleFonts.montserrat(
-                              fontSize: 16,
-                              color: textColor,
-                            ),
-                            decoration: InputDecoration(
-                              hintText: 'Phone number',
-                              hintStyle: GoogleFonts.montserrat(
-                                color: Colors.grey,
-                              ),
-                              border: InputBorder.none,
-                              contentPadding: const EdgeInsets.symmetric(
-                                horizontal: 16,
-                                vertical: 16,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-
-                  const SizedBox(height: 40),
-
-                  // Continue Button - Styled like phone signup
-                  SizedBox(
-                    width: double.infinity,
-                    height: 56,
-                    child: ElevatedButton(
-                      onPressed: _isLoading ? null : _verifyPhoneNumber,
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor:
-                            _isLoading ? Colors.grey.shade400 : primaryColor,
-                        foregroundColor: Colors.white,
-                        disabledBackgroundColor: Colors.grey.shade400,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(16),
-                        ),
-                        elevation: _isLoading ? 1 : 3,
-                        shadowColor: _isLoading
-                            ? Colors.transparent
-                            : primaryColor.withValues(alpha: 0.3),
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                // Phone icon with Afrocentric style
+                Container(
+                  width: 100,
+                  height: 100,
+                  decoration: BoxDecoration(
+                    color: iconBackgroundColor,
+                    shape: BoxShape.circle,
+                    boxShadow: [
+                      BoxShadow(
+                        color: primaryColor.withValues(alpha: 0.2),
+                        blurRadius: 15,
+                        offset: const Offset(0, 5),
                       ),
-                      child: _isLoading
-                          ? const SizedBox(
-                              height: 24,
-                              width: 24,
-                              child: CircularProgressIndicator(
-                                color: Colors.white,
-                                strokeWidth: 2,
-                              ),
-                            )
-                          : Text(
-                              'Continue',
-                              style: GoogleFonts.montserrat(
-                                fontSize: 18,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                    ),
+                    ],
                   ),
+                  child: const Icon(
+                    Icons.phone_android,
+                    color: primaryColor,
+                    size: 50,
+                  ),
+                ),
 
-                  const SizedBox(height: 40),
+                const SizedBox(height: 32),
 
-                  // Don't have an account? Sign up
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
+                Text(
+                  'Enter your phone number',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 24,
+                    fontWeight: FontWeight.w600,
+                    color: primaryColor,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  "We'll send you a verification code",
+                  style: GoogleFonts.montserrat(
+                    fontSize: 16,
+                    color: subtextColor,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 40),
+
+                // Phone number input with country code
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    borderRadius: BorderRadius.circular(16),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withValues(alpha: 0.05),
+                        blurRadius: 10,
+                        offset: const Offset(0, 5),
+                      ),
+                    ],
+                  ),
+                  child: Row(
                     children: [
-                      Text(
-                        "Don't have an account? ",
-                        style: GoogleFonts.montserrat(
-                          fontSize: 14,
-                          color: textColor,
+                      // Country code dropdown
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                        decoration: BoxDecoration(
+                          border: Border(
+                            right: BorderSide(
+                              color: Colors.grey.withValues(alpha: 0.3),
+                            ),
+                          ),
+                        ),
+                        child: DropdownButton<String>(
+                          value: _selectedCountryCode,
+                          icon: const Icon(Icons.arrow_drop_down),
+                          elevation: 16,
+                          style: GoogleFonts.montserrat(
+                            fontSize: 16,
+                            color: textColor,
+                          ),
+                          underline: Container(
+                            height: 0,
+                          ),
+                          onChanged: (String? newValue) {
+                            setState(() {
+                              _selectedCountryCode = newValue!;
+                            });
+                          },
+                          items: _countryCodes
+                              .map<DropdownMenuItem<String>>(
+                                (Map<String, String> value) =>
+                                    DropdownMenuItem<String>(
+                                  value: value['code'],
+                                  child: Text(
+                                    "${value['code']} (${value['name']})",
+                                  ),
+                                ),
+                              )
+                              .toList(),
                         ),
                       ),
-                      GestureDetector(
-                        onTap: () {
-                          unawaited(
-                            Navigator.pushReplacementNamed(
-                              context,
-                              '/welcome',
-                            ),
-                          );
-                        },
-                        child: Text(
-                          'Sign Up',
+
+                      // Phone number input
+                      Expanded(
+                        child: TextField(
+                          controller: _phoneController,
+                          keyboardType: TextInputType.phone,
                           style: GoogleFonts.montserrat(
-                            fontSize: 14,
-                            fontWeight: FontWeight.w600,
-                            color: primaryColor,
+                            fontSize: 16,
+                            color: textColor,
+                          ),
+                          decoration: InputDecoration(
+                            hintText: 'Phone number',
+                            hintStyle: GoogleFonts.montserrat(
+                              color: Colors.grey,
+                            ),
+                            border: InputBorder.none,
+                            contentPadding: const EdgeInsets.symmetric(
+                              horizontal: 16,
+                              vertical: 16,
+                            ),
                           ),
                         ),
                       ),
                     ],
                   ),
+                ),
 
-                  const SizedBox(height: 24),
-                ],
-              ),
+                const SizedBox(height: 40),
+
+                // Continue Button - Styled like phone signup
+                SizedBox(
+                  width: double.infinity,
+                  height: 56,
+                  child: ElevatedButton(
+                    onPressed: _isLoading ? null : _verifyPhoneNumber,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor:
+                          _isLoading ? Colors.grey.shade400 : primaryColor,
+                      foregroundColor: Colors.white,
+                      disabledBackgroundColor: Colors.grey.shade400,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                      elevation: _isLoading ? 1 : 3,
+                      shadowColor: _isLoading
+                          ? Colors.transparent
+                          : primaryColor.withValues(alpha: 0.3),
+                    ),
+                    child: _isLoading
+                        ? const SizedBox(
+                            height: 24,
+                            width: 24,
+                            child: CircularProgressIndicator(
+                              color: Colors.white,
+                              strokeWidth: 2,
+                            ),
+                          )
+                        : Text(
+                            'Continue',
+                            style: GoogleFonts.montserrat(
+                              fontSize: 18,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                  ),
+                ),
+
+                const SizedBox(height: 40),
+
+                // Don't have an account? Sign up
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(
+                      "Don't have an account? ",
+                      style: GoogleFonts.montserrat(
+                        fontSize: 14,
+                        color: textColor,
+                      ),
+                    ),
+                    GestureDetector(
+                      onTap: () {
+                        unawaited(
+                          Navigator.pushReplacementNamed(
+                            context,
+                            '/welcome',
+                          ),
+                        );
+                      },
+                      child: Text(
+                        'Sign Up',
+                        style: GoogleFonts.montserrat(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w600,
+                          color: primaryColor,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+
+                const SizedBox(height: 24),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/features/auth/phone/ui/screens/phone_number.dart
+++ b/lib/features/auth/phone/ui/screens/phone_number.dart
@@ -233,322 +233,318 @@ class _PhoneNumberState extends State<PhoneNumber> {
                 SafeArea(
                   child: Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 24),
-                  child: SingleChildScrollView(
-                    keyboardDismissBehavior:
-                        ScrollViewKeyboardDismissBehavior.onDrag,
-                    child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            const AuthIconContainer(
-                              icon: Icons.phone_android,
-                              backgroundColor: Color(0x33FFFFFF),
-                              iconColor: Colors.white,
-                            ),
-                            const SizedBox(height: 32),
-                            if (kDebugMode && Platform.isIOS)
-                              Container(
-                                margin: const EdgeInsets.only(bottom: 20),
-                                padding: const EdgeInsets.all(12),
-                                decoration: BoxDecoration(
-                                  color: Colors.blue.shade50
-                                      .withValues(alpha: 0.15),
-                                  borderRadius: BorderRadius.circular(8),
-                                  border: Border.all(
-                                    color: Colors.blue.shade200
-                                        .withValues(alpha: 0.4),
-                                  ),
-                                ),
-                                child: Row(
-                                  children: [
-                                    Icon(
-                                      Icons.info_outline,
-                                      color: Colors.blue.shade200,
-                                      size: 20,
-                                    ),
-                                    const SizedBox(width: 8),
-                                    Expanded(
-                                      child: Text(
-                                        '💡 iOS Simulator: Use test phone numbers from Firebase Console',
-                                        style: GoogleFonts.montserrat(
-                                          fontSize: 12,
-                                          color: Colors.blue.shade100,
-                                        ),
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            Text(
-                              'Enter your phone number',
-                              style: GoogleFonts.montserrat(
-                                fontSize: 24,
-                                fontWeight: FontWeight.w600,
-                                color: Colors.white,
-                              ),
-                              textAlign: TextAlign.center,
-                            ),
-                            const SizedBox(height: 12),
-                            Text(
-                              "We'll send you a verification code",
-                              style: GoogleFonts.montserrat(
-                                fontSize: 16,
-                                color: const Color(0xB3FFFFFF),
-                              ),
-                              textAlign: TextAlign.center,
-                            ),
-                            const SizedBox(height: 40),
+                    child: SingleChildScrollView(
+                      keyboardDismissBehavior:
+                          ScrollViewKeyboardDismissBehavior.onDrag,
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          const AuthIconContainer(
+                            icon: Icons.phone_android,
+                            backgroundColor: Color(0x33FFFFFF),
+                            iconColor: Colors.white,
+                          ),
+                          const SizedBox(height: 32),
+                          if (kDebugMode && Platform.isIOS)
                             Container(
-                              height: 60,
+                              margin: const EdgeInsets.only(bottom: 20),
+                              padding: const EdgeInsets.all(12),
                               decoration: BoxDecoration(
-                                color: Colors.white.withValues(alpha: 0.92),
-                                borderRadius: BorderRadius.circular(16),
+                                color:
+                                    Colors.blue.shade50.withValues(alpha: 0.15),
+                                borderRadius: BorderRadius.circular(8),
                                 border: Border.all(
-                                  color: isValidNumber
-                                      ? AppColors.primaryGreen
-                                      : Colors.grey.shade300,
-                                  width: isValidNumber ? 1.5 : 1,
+                                  color: Colors.blue.shade200
+                                      .withValues(alpha: 0.4),
                                 ),
                               ),
                               child: Row(
                                 children: [
-                                  Container(
-                                    padding: const EdgeInsets.only(left: 8),
-                                    child: CountryCodePicker(
-                                      onChanged: (CountryCode code) {
-                                        if (mounted) {
-                                          setState(() {
-                                            countryCode = code.dialCode ?? '+1';
-                                            _regionCode = code.code ?? 'US';
-                                            _validatePhoneNumber();
-                                          });
-                                        }
-                                      },
-                                      initialSelection: 'US',
-                                      favorite: const [
-                                        'US',
-                                        'GH',
-                                        'ZA',
-                                        'KE',
-                                        'US',
-                                        'GB',
-                                      ],
-                                      textStyle: GoogleFonts.montserrat(
-                                        color: AppColors.textPrimary,
-                                        fontSize: 16,
-                                        fontWeight: FontWeight.w500,
-                                      ),
-                                      dialogTextStyle: GoogleFonts.montserrat(
-                                        color: Colors.black,
-                                        fontSize: 16,
-                                      ),
-                                      searchStyle: GoogleFonts.montserrat(
-                                        color: Colors.black,
-                                        fontSize: 16,
-                                      ),
-                                      dialogBackgroundColor: Colors.white,
-                                      boxDecoration: BoxDecoration(
-                                        color: Colors.white,
-                                        borderRadius: BorderRadius.circular(8),
-                                      ),
-                                      barrierColor: Colors.black54,
-                                      backgroundColor: Colors.white,
-                                      dialogSize: Size(
-                                        MediaQuery.of(context).size.width * 0.9,
-                                        MediaQuery.of(context).size.height *
-                                            0.7,
-                                      ),
-                                      headerTextStyle: GoogleFonts.montserrat(
-                                        color: Colors.black,
-                                        fontSize: 18,
-                                        fontWeight: FontWeight.bold,
-                                      ),
-                                      searchDecoration: InputDecoration(
-                                        hintText: 'Search country',
-                                        hintStyle: GoogleFonts.montserrat(
-                                          color: Colors.grey.shade600,
-                                          fontSize: 16,
-                                        ),
-                                        prefixIcon: const Icon(
-                                          Icons.search,
-                                          color: AppColors.primaryGreen,
-                                        ),
-                                        filled: true,
-                                        fillColor: Colors.white,
-                                        border: OutlineInputBorder(
-                                          borderRadius:
-                                              BorderRadius.circular(12),
-                                          borderSide: BorderSide(
-                                            color: Colors.grey.shade300,
-                                          ),
-                                        ),
-                                        enabledBorder: OutlineInputBorder(
-                                          borderRadius:
-                                              BorderRadius.circular(12),
-                                          borderSide: BorderSide(
-                                            color: Colors.grey.shade300,
-                                          ),
-                                        ),
-                                        focusedBorder: OutlineInputBorder(
-                                          borderRadius:
-                                              BorderRadius.circular(12),
-                                          borderSide: const BorderSide(
-                                            color: AppColors.primaryGreen,
-                                            width: 1.5,
-                                          ),
-                                        ),
-                                        contentPadding:
-                                            const EdgeInsets.symmetric(
-                                          horizontal: 16,
-                                          vertical: 12,
-                                        ),
-                                      ),
-                                    ),
+                                  Icon(
+                                    Icons.info_outline,
+                                    color: Colors.blue.shade200,
+                                    size: 20,
                                   ),
-                                  Container(
-                                    height: 30,
-                                    width: 1,
-                                    color: Colors.grey.withValues(alpha: 0.3),
-                                  ),
+                                  const SizedBox(width: 8),
                                   Expanded(
-                                    child: TextField(
-                                      controller: phoneNumberController,
-                                      keyboardType: TextInputType.phone,
+                                    child: Text(
+                                      '💡 iOS Simulator: Use test phone numbers from Firebase Console',
                                       style: GoogleFonts.montserrat(
-                                        fontSize: 16,
-                                        color: AppColors.textPrimary,
-                                        fontWeight: FontWeight.w500,
+                                        fontSize: 12,
+                                        color: Colors.blue.shade100,
                                       ),
-                                      decoration: InputDecoration(
-                                        hintText: 'Phone number',
-                                        hintStyle: GoogleFonts.montserrat(
-                                          color: Colors.grey,
-                                          fontWeight: FontWeight.w400,
-                                        ),
-                                        border: InputBorder.none,
-                                        contentPadding:
-                                            const EdgeInsets.symmetric(
-                                          horizontal: 16,
-                                          vertical: 16,
-                                        ),
-                                      ),
-                                      inputFormatters: [
-                                        FilteringTextInputFormatter.digitsOnly,
-                                        _PhoneNumberFormatter(),
-                                      ],
                                     ),
                                   ),
                                 ],
                               ),
                             ),
-                            const SizedBox(height: 40),
-                            Center(
-                              child: SizedBox(
-                                width: buttonWidth,
-                                child: Builder(
-                                  builder: (builderContext) =>
-                                      AfropeepPrimaryButton(
-                                    text: 'Continue',
-                                    isLoading: _isLoading,
-                                    disabledBackgroundColor:
-                                        Colors.white.withValues(alpha: 0.15),
-                                    onPressed: isValidNumber && !_isLoading
-                                        ? () {
-                                            _authDebugLog(
-                                              'Phone auth button tapped: '
-                                              'isValid=$isValidNumber '
-                                              'isLoading=$_isLoading',
-                                            );
-
-                                            setState(() {
-                                              _isLoading = true;
-                                            });
-
-                                            final cleanPhoneNumber =
-                                                phoneNumberController.text
-                                                    .replaceAll(' ', '')
-                                                    .replaceAll('-', '')
-                                                    .replaceAll('(', '')
-                                                    .replaceAll(')', '')
-                                                    .trim();
-
-                                            final fullPhoneNumber =
-                                                countryCode + cleanPhoneNumber;
-
-                                            _authDebugLog(
-                                              'Phone auth request prepared: '
-                                              'country=$countryCode '
-                                              'digits=${cleanPhoneNumber.length}',
-                                            );
-
-                                            final bloc =
-                                                BlocProvider.of<PhoneAuthBloc>(
-                                              builderContext,
-                                            );
-                                            bloc.add(
-                                              SendOtpToPhoneEvent(
-                                                phoneNumber: fullPhoneNumber,
-                                              ),
-                                            );
-                                          }
-                                        : null,
-                                  ),
-                                ),
+                          Text(
+                            'Enter your phone number',
+                            style: GoogleFonts.montserrat(
+                              fontSize: 24,
+                              fontWeight: FontWeight.w600,
+                              color: Colors.white,
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                          const SizedBox(height: 12),
+                          Text(
+                            "We'll send you a verification code",
+                            style: GoogleFonts.montserrat(
+                              fontSize: 16,
+                              color: const Color(0xB3FFFFFF),
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                          const SizedBox(height: 40),
+                          Container(
+                            height: 60,
+                            decoration: BoxDecoration(
+                              color: Colors.white.withValues(alpha: 0.92),
+                              borderRadius: BorderRadius.circular(16),
+                              border: Border.all(
+                                color: isValidNumber
+                                    ? AppColors.primaryGreen
+                                    : Colors.grey.shade300,
+                                width: isValidNumber ? 1.5 : 1,
                               ),
                             ),
-                            const SizedBox(height: 24),
-                            Text(
-                              'By continuing, you agree to receive SMS messages for verification and may be subject to carrier fees.',
-                              textAlign: TextAlign.center,
-                              style: GoogleFonts.montserrat(
-                                fontSize: 12,
-                                color: const Color(0x99FFFFFF),
-                              ),
-                            ),
-                            const SizedBox(height: 40),
-                            Row(
-                              mainAxisAlignment: MainAxisAlignment.center,
+                            child: Row(
                               children: [
-                                Text(
-                                  widget.isSignIn
-                                      ? "Don't have an account? "
-                                      : 'Already have an account? ',
-                                  style: GoogleFonts.montserrat(
-                                    fontSize: 14,
-                                    color: const Color(0xB3FFFFFF),
+                                Container(
+                                  padding: const EdgeInsets.only(left: 8),
+                                  child: CountryCodePicker(
+                                    onChanged: (CountryCode code) {
+                                      if (mounted) {
+                                        setState(() {
+                                          countryCode = code.dialCode ?? '+1';
+                                          _regionCode = code.code ?? 'US';
+                                          _validatePhoneNumber();
+                                        });
+                                      }
+                                    },
+                                    initialSelection: 'US',
+                                    favorite: const [
+                                      'US',
+                                      'GH',
+                                      'ZA',
+                                      'KE',
+                                      'US',
+                                      'GB',
+                                    ],
+                                    textStyle: GoogleFonts.montserrat(
+                                      color: AppColors.textPrimary,
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w500,
+                                    ),
+                                    dialogTextStyle: GoogleFonts.montserrat(
+                                      color: Colors.black,
+                                      fontSize: 16,
+                                    ),
+                                    searchStyle: GoogleFonts.montserrat(
+                                      color: Colors.black,
+                                      fontSize: 16,
+                                    ),
+                                    dialogBackgroundColor: Colors.white,
+                                    boxDecoration: BoxDecoration(
+                                      color: Colors.white,
+                                      borderRadius: BorderRadius.circular(8),
+                                    ),
+                                    barrierColor: Colors.black54,
+                                    backgroundColor: Colors.white,
+                                    dialogSize: Size(
+                                      MediaQuery.of(context).size.width * 0.9,
+                                      MediaQuery.of(context).size.height * 0.7,
+                                    ),
+                                    headerTextStyle: GoogleFonts.montserrat(
+                                      color: Colors.black,
+                                      fontSize: 18,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                    searchDecoration: InputDecoration(
+                                      hintText: 'Search country',
+                                      hintStyle: GoogleFonts.montserrat(
+                                        color: Colors.grey.shade600,
+                                        fontSize: 16,
+                                      ),
+                                      prefixIcon: const Icon(
+                                        Icons.search,
+                                        color: AppColors.primaryGreen,
+                                      ),
+                                      filled: true,
+                                      fillColor: Colors.white,
+                                      border: OutlineInputBorder(
+                                        borderRadius: BorderRadius.circular(12),
+                                        borderSide: BorderSide(
+                                          color: Colors.grey.shade300,
+                                        ),
+                                      ),
+                                      enabledBorder: OutlineInputBorder(
+                                        borderRadius: BorderRadius.circular(12),
+                                        borderSide: BorderSide(
+                                          color: Colors.grey.shade300,
+                                        ),
+                                      ),
+                                      focusedBorder: OutlineInputBorder(
+                                        borderRadius: BorderRadius.circular(12),
+                                        borderSide: const BorderSide(
+                                          color: AppColors.primaryGreen,
+                                          width: 1.5,
+                                        ),
+                                      ),
+                                      contentPadding:
+                                          const EdgeInsets.symmetric(
+                                        horizontal: 16,
+                                        vertical: 12,
+                                      ),
+                                    ),
                                   ),
                                 ),
-                                GestureDetector(
-                                  onTap: () {
-                                    if (widget.isSignIn) {
-                                      unawaited(
-                                        Navigator.pushReplacementNamed(
-                                          context,
-                                          '/auth_method_selection',
-                                        ),
-                                      );
-                                    } else {
-                                      unawaited(
-                                        Navigator.pushReplacementNamed(
-                                          context,
-                                          '/sign_in_method_selection',
-                                        ),
-                                      );
-                                    }
-                                  },
-                                  child: Text(
-                                    widget.isSignIn ? 'Create one' : 'Sign in',
+                                Container(
+                                  height: 30,
+                                  width: 1,
+                                  color: Colors.grey.withValues(alpha: 0.3),
+                                ),
+                                Expanded(
+                                  child: TextField(
+                                    controller: phoneNumberController,
+                                    keyboardType: TextInputType.phone,
                                     style: GoogleFonts.montserrat(
-                                      fontSize: 14,
-                                      fontWeight: FontWeight.w600,
-                                      color: Colors.white,
+                                      fontSize: 16,
+                                      color: AppColors.textPrimary,
+                                      fontWeight: FontWeight.w500,
                                     ),
+                                    decoration: InputDecoration(
+                                      hintText: 'Phone number',
+                                      hintStyle: GoogleFonts.montserrat(
+                                        color: Colors.grey,
+                                        fontWeight: FontWeight.w400,
+                                      ),
+                                      border: InputBorder.none,
+                                      contentPadding:
+                                          const EdgeInsets.symmetric(
+                                        horizontal: 16,
+                                        vertical: 16,
+                                      ),
+                                    ),
+                                    inputFormatters: [
+                                      FilteringTextInputFormatter.digitsOnly,
+                                      _PhoneNumberFormatter(),
+                                    ],
                                   ),
                                 ),
                               ],
                             ),
-                          ],
-                        ),
+                          ),
+                          const SizedBox(height: 40),
+                          Center(
+                            child: SizedBox(
+                              width: buttonWidth,
+                              child: Builder(
+                                builder: (builderContext) =>
+                                    AfropeepPrimaryButton(
+                                  text: 'Continue',
+                                  isLoading: _isLoading,
+                                  disabledBackgroundColor:
+                                      Colors.white.withValues(alpha: 0.15),
+                                  onPressed: isValidNumber && !_isLoading
+                                      ? () {
+                                          _authDebugLog(
+                                            'Phone auth button tapped: '
+                                            'isValid=$isValidNumber '
+                                            'isLoading=$_isLoading',
+                                          );
+
+                                          setState(() {
+                                            _isLoading = true;
+                                          });
+
+                                          final cleanPhoneNumber =
+                                              phoneNumberController.text
+                                                  .replaceAll(' ', '')
+                                                  .replaceAll('-', '')
+                                                  .replaceAll('(', '')
+                                                  .replaceAll(')', '')
+                                                  .trim();
+
+                                          final fullPhoneNumber =
+                                              countryCode + cleanPhoneNumber;
+
+                                          _authDebugLog(
+                                            'Phone auth request prepared: '
+                                            'country=$countryCode '
+                                            'digits=${cleanPhoneNumber.length}',
+                                          );
+
+                                          final bloc =
+                                              BlocProvider.of<PhoneAuthBloc>(
+                                            builderContext,
+                                          );
+                                          bloc.add(
+                                            SendOtpToPhoneEvent(
+                                              phoneNumber: fullPhoneNumber,
+                                            ),
+                                          );
+                                        }
+                                      : null,
+                                ),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 24),
+                          Text(
+                            'By continuing, you agree to receive SMS messages for verification and may be subject to carrier fees.',
+                            textAlign: TextAlign.center,
+                            style: GoogleFonts.montserrat(
+                              fontSize: 12,
+                              color: const Color(0x99FFFFFF),
+                            ),
+                          ),
+                          const SizedBox(height: 40),
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Text(
+                                widget.isSignIn
+                                    ? "Don't have an account? "
+                                    : 'Already have an account? ',
+                                style: GoogleFonts.montserrat(
+                                  fontSize: 14,
+                                  color: const Color(0xB3FFFFFF),
+                                ),
+                              ),
+                              GestureDetector(
+                                onTap: () {
+                                  if (widget.isSignIn) {
+                                    unawaited(
+                                      Navigator.pushReplacementNamed(
+                                        context,
+                                        '/auth_method_selection',
+                                      ),
+                                    );
+                                  } else {
+                                    unawaited(
+                                      Navigator.pushReplacementNamed(
+                                        context,
+                                        '/sign_in_method_selection',
+                                      ),
+                                    );
+                                  }
+                                },
+                                child: Text(
+                                  widget.isSignIn ? 'Create one' : 'Sign in',
+                                  style: GoogleFonts.montserrat(
+                                    fontSize: 14,
+                                    fontWeight: FontWeight.w600,
+                                    color: Colors.white,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
                       ),
+                    ),
                   ),
                 ),
               ],

--- a/lib/features/auth/phone/ui/screens/phone_number.dart
+++ b/lib/features/auth/phone/ui/screens/phone_number.dart
@@ -233,9 +233,10 @@ class _PhoneNumberState extends State<PhoneNumber> {
                 SafeArea(
                   child: Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 24),
-                    child: Center(
-                      child: SingleChildScrollView(
-                        child: Column(
+                  child: SingleChildScrollView(
+                    keyboardDismissBehavior:
+                        ScrollViewKeyboardDismissBehavior.onDrag,
+                    child: Column(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
                             const AuthIconContainer(
@@ -548,7 +549,6 @@ class _PhoneNumberState extends State<PhoneNumber> {
                           ],
                         ),
                       ),
-                    ),
                   ),
                 ),
               ],

--- a/lib/features/onboarding/data/repositories/onboarding_repository.dart
+++ b/lib/features/onboarding/data/repositories/onboarding_repository.dart
@@ -20,34 +20,61 @@ class OnboardingRepository {
 
     AppLogger.info('🔍 Saving essential user data to Firestore...');
 
-    // Firestore rules lock `createdAt` after initial creation.
-    // Keep it only on first write; never attempt to mutate it later.
-    final snapshot = await userRef.get();
-    if (snapshot.exists) {
-      essentialData.remove('createdAt');
-      final existing = snapshot.data() ?? <String, dynamic>{};
+    Future<void> writeWithSnapshot(
+      DocumentSnapshot<Map<String, dynamic>> snap,
+      Map<String, dynamic> sourceData,
+    ) async {
+      final payload = _sanitizeForUserRules(
+        input: Map<String, dynamic>.from(sourceData),
+        existing: snap.data() ?? <String, dynamic>{},
+        isExistingDoc: snap.exists,
+      )..['updatedAt'] = FieldValue.serverTimestamp();
 
-      final isIdentityLocked = existing['onboardingCompleted'] == true ||
-          existing['profileSetupComplete'] == true ||
-          existing['isProfileComplete'] == true;
-
-      // Firestore rules lock name/dateOfBirth after onboarding is marked complete.
-      // Keep existing locked values to make retries idempotent.
-      if (isIdentityLocked) {
-        if (existing.containsKey('name')) {
-          essentialData['name'] = existing['name'];
-        }
-        if (existing.containsKey('dateOfBirth')) {
-          essentialData['dateOfBirth'] = existing['dateOfBirth'];
-        }
+      if (snap.exists) {
+        await userRef.update(payload);
+      } else {
+        await userRef.set(payload, SetOptions(merge: true));
       }
     }
 
-    await userRef.set(essentialData, SetOptions(merge: true));
+    final currentUser = FirebaseAuth.instance.currentUser;
+    if (currentUser != null) {
+      // Reduce transient auth/rules propagation race after fresh sign-in.
+      await currentUser.getIdToken(true);
+    }
 
-    await userRef.update({
-      'updatedAt': FieldValue.serverTimestamp(),
-    });
+    Future<void> saveAttempt() async {
+      final snapshot = await userRef.get();
+      await writeWithSnapshot(snapshot, essentialData);
+    }
+
+    try {
+      await saveAttempt();
+    } on FirebaseException catch (e) {
+      if (e.code != 'permission-denied' && e.code != 'unauthenticated') {
+        rethrow;
+      }
+      AppLogger.warning(
+        '⚠️ Onboarding save denied; refreshing token and retrying once',
+      );
+      if (currentUser != null) {
+        await currentUser.getIdToken(true);
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 350));
+      try {
+        await saveAttempt();
+      } on FirebaseException catch (retryError) {
+        if (retryError.code != 'permission-denied') {
+          rethrow;
+        }
+        AppLogger.warning(
+          '⚠️ Onboarding write still denied; trying legacy-compatible payload',
+        );
+        final snapshot = await userRef.get();
+        final legacyPayload = _buildLegacyCompatibleData(data);
+        await writeWithSnapshot(snapshot, legacyPayload);
+      }
+    }
 
     final user = FirebaseAuth.instance.currentUser;
     if (user != null) {
@@ -55,6 +82,59 @@ class OnboardingRepository {
     }
 
     AppLogger.info('✅ Essential user data saved successfully');
+  }
+
+  Map<String, dynamic> _buildLegacyCompatibleData(OnboardingData d) => {
+        'name': d.fullName,
+        'dateOfBirth': d.dateOfBirth?.toIso8601String(),
+        'age': d.age,
+        'gender': d.gender,
+        'bio': d.bio,
+        'interests': d.interests,
+        'height': d.height,
+        'lookingFor': d.lookingFor,
+        'relationshipIntent': d.relationshipIntent,
+        'interestedIn': d.interestedIn,
+        'ageRange': {
+          'min': d.ageRange[0].toString(),
+          'max': d.ageRange[1].toString(),
+        },
+        'maxDistance': d.maxDistance,
+        'locationName': d.locationName,
+        'latitude': d.latitude ?? 6.5244,
+        'longitude': d.longitude ?? 3.3792,
+        'onboardingCompleted': true,
+        'profileSetupComplete': true,
+        'isProfileComplete': true,
+      };
+
+  Map<String, dynamic> _sanitizeForUserRules({
+    required Map<String, dynamic> input,
+    required Map<String, dynamic> existing,
+    required bool isExistingDoc,
+  }) {
+    // Immutable/server-managed fields blocked by Firestore rules.
+    input.remove('uid');
+    input.remove('email');
+    input.remove('signInMethod');
+    input.remove('isDiscoverable');
+
+    if (isExistingDoc) {
+      // Rule blocks mutating createdAt after create.
+      input.remove('createdAt');
+    }
+
+    final isIdentityLocked = existing['onboardingCompleted'] == true ||
+        existing['profileSetupComplete'] == true ||
+        existing['isProfileComplete'] == true;
+
+    if (isIdentityLocked) {
+      // Never attempt to change locked identity fields on retries.
+      input.remove('name');
+      input.remove('dateOfBirth');
+    }
+
+    return input;
   }
 
   Future<void> uploadProfilePictures({
@@ -208,9 +288,8 @@ class OnboardingRepository {
       'locationName': d.locationName,
       'latitude': d.latitude ?? 6.5244,
       'longitude': d.longitude ?? 3.3792,
-      // Canonical flag + legacy synonyms. All three must be set so the
-      // Firestore security rule isLockedIdentityFieldUpdate() activates
-      // regardless of which flag name a query or rule references.
+      // Canonical flag + legacy synonyms for queries and older clients.
+      // Firestore identity lock uses onboardingCompleted only (see firestore.rules).
       'onboardingCompleted': true,
       'profileSetupComplete': true,
       'isProfileComplete': true,

--- a/lib/features/onboarding/onboarding_main.dart
+++ b/lib/features/onboarding/onboarding_main.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:google_fonts/google_fonts.dart';
 
-import '../../common/widgets/build_stamp.dart';
 import 'bloc/onboarding_bloc.dart';
 import 'onboarding_theme.dart';
 import 'screens/basic_info_screen.dart';
@@ -128,25 +127,13 @@ class _OnboardingMainState extends State<OnboardingMain> {
       }
     } else if (_currentPage == 7) {
       final missingPurpose = data.lookingFor.trim().isEmpty;
-      final missingIntent = data.relationshipIntent.trim().isEmpty;
-      if (missingPurpose && missingIntent) {
+      final requiresRelationshipIntent = data.lookingFor == 'Dating';
+      final missingIntent =
+          requiresRelationshipIntent && data.relationshipIntent.trim().isEmpty;
+      if (missingPurpose || missingIntent) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
             content: Text('Please complete all required fields on this page'),
-          ),
-        );
-        return;
-      }
-      if (missingPurpose) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Please select what brings you here')),
-        );
-        return;
-      }
-      if (missingIntent) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Please select your relationship goals'),
           ),
         );
         return;
@@ -204,13 +191,12 @@ class _OnboardingMainState extends State<OnboardingMain> {
 
   @override
   Widget build(BuildContext context) {
-    final bottomSafe = MediaQuery.of(context).padding.bottom;
     final keyboardInset = MediaQuery.of(context).viewInsets.bottom;
-    final bottomPadding = keyboardInset > 0
-        ? keyboardInset + 12
-        : math.max(16, bottomSafe).toDouble();
+    final bottomSafe = MediaQuery.of(context).padding.bottom;
+    final bottomPadding = math.max(16, bottomSafe).toDouble();
 
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       backgroundColor: OnboardingTheme.background,
       appBar: AppBar(
         backgroundColor: Colors.transparent,
@@ -278,7 +264,6 @@ class _OnboardingMainState extends State<OnboardingMain> {
                 ),
               ),
 
-              // Bottom CTA
               AnimatedPadding(
                 duration: const Duration(milliseconds: 220),
                 curve: Curves.easeOut,
@@ -286,7 +271,8 @@ class _OnboardingMainState extends State<OnboardingMain> {
                   left: OnboardingTheme.horizontalPadding,
                   right: OnboardingTheme.horizontalPadding,
                   top: 16,
-                  bottom: bottomPadding,
+                  bottom:
+                      keyboardInset > 0 ? keyboardInset + 12 : bottomPadding,
                 ),
                 child: BlocBuilder<OnboardingBloc, OnboardingState>(
                   buildWhen: (prev, curr) =>
@@ -314,8 +300,11 @@ class _OnboardingMainState extends State<OnboardingMain> {
                         case 6:
                           canContinue = data.interestedIn.isNotEmpty;
                         case 7:
+                          final requiresRelationshipIntent =
+                              data.lookingFor == 'Dating';
                           canContinue = data.lookingFor.trim().isNotEmpty &&
-                              data.relationshipIntent.trim().isNotEmpty;
+                              (!requiresRelationshipIntent ||
+                                  data.relationshipIntent.trim().isNotEmpty);
                       }
                     }
 
@@ -361,11 +350,6 @@ class _OnboardingMainState extends State<OnboardingMain> {
                 ),
               ),
             ],
-          ),
-          const Positioned(
-            right: 12,
-            bottom: 12,
-            child: BuildStamp(compact: true),
           ),
         ],
       ),

--- a/lib/features/onboarding/onboarding_theme.dart
+++ b/lib/features/onboarding/onboarding_theme.dart
@@ -201,7 +201,8 @@ class OnboardingTheme {
   // ---------------------------------------------------------------------------
   // Constrained content wrapper for tablet
   // ---------------------------------------------------------------------------
-  static Widget constrainedContent({required Widget child}) => Center(
+  static Widget constrainedContent({required Widget child}) => Align(
+        alignment: Alignment.topCenter,
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: maxContentWidth),
           child: child,

--- a/lib/features/onboarding/screens/enhanced_additional_info_screen.dart
+++ b/lib/features/onboarding/screens/enhanced_additional_info_screen.dart
@@ -40,12 +40,6 @@ class _EnhancedAdditionalInfoScreenState
       'icon': Icons.business_center,
       'color': Colors.green.shade400,
     },
-    {
-      'label': 'All of the Above',
-      'value': 'All of the Above',
-      'icon': Icons.explore,
-      'color': Colors.purple.shade400,
-    },
   ];
 
   final List<Map<String, dynamic>> _relationshipIntentOptions = [
@@ -110,8 +104,6 @@ class _EnhancedAdditionalInfoScreenState
         displayValue = 'Friendship & Social';
       case 'Networking':
         displayValue = 'Professional Networking';
-      case 'Mixed':
-        displayValue = 'All of the Above';
       default:
         displayValue = '';
     }
@@ -211,6 +203,9 @@ class _EnhancedAdditionalInfoScreenState
                 onChanged: (value) {
                   setState(() {
                     _platformPurpose = value;
+                    if (!_shouldShowRelationshipGoals()) {
+                      _relationshipIntent = '';
+                    }
                   });
                   String controllerValue;
                   switch (value) {
@@ -220,49 +215,58 @@ class _EnhancedAdditionalInfoScreenState
                       controllerValue = 'Friendship';
                     case 'Professional Networking':
                       controllerValue = 'Networking';
-                    case 'All of the Above':
-                      controllerValue = 'Mixed';
                     default:
-                      controllerValue = 'Dating';
+                      controllerValue = '';
                   }
-                  context.read<OnboardingBloc>().add(
-                        OnboardingLookingForUpdated(controllerValue),
-                      );
+                  if (controllerValue.isNotEmpty) {
+                    context.read<OnboardingBloc>().add(
+                          OnboardingLookingForUpdated(controllerValue),
+                        );
+                  }
+                  if (!_shouldShowRelationshipGoals()) {
+                    context.read<OnboardingBloc>().add(
+                          const OnboardingRelationshipIntentUpdated(''),
+                        );
+                  }
                 },
               ),
 
-              const SizedBox(height: OnboardingTheme.fieldToSection),
+              if (_shouldShowRelationshipGoals()) ...[
+                const SizedBox(height: OnboardingTheme.fieldToSection),
 
-              // 3. Relationship Goals
-              Text(
-                'Relationship goals',
-                style: OnboardingTheme.sectionLabelStyle,
-              ),
-              const SizedBox(height: 4),
-              Text(
-                'What are you hoping to find?',
-                style: OnboardingTheme.helperStyle,
-              ),
-              const SizedBox(height: OnboardingTheme.labelToField),
-              _buildDropdown(
-                value: _relationshipIntent,
-                options: _relationshipIntentOptions,
-                hint: 'Select your relationship goals',
-                onChanged: (value) {
-                  setState(() {
-                    _relationshipIntent = value;
-                  });
-                  context.read<OnboardingBloc>().add(
-                        OnboardingRelationshipIntentUpdated(value),
-                      );
-                },
-              ),
+                // 3. Relationship Goals (dating-only)
+                Text(
+                  'Relationship goals',
+                  style: OnboardingTheme.sectionLabelStyle,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'What are you hoping to find?',
+                  style: OnboardingTheme.helperStyle,
+                ),
+                const SizedBox(height: OnboardingTheme.labelToField),
+                _buildDropdown(
+                  value: _relationshipIntent,
+                  options: _relationshipIntentOptions,
+                  hint: 'Select your relationship goals',
+                  onChanged: (value) {
+                    setState(() {
+                      _relationshipIntent = value;
+                    });
+                    context.read<OnboardingBloc>().add(
+                          OnboardingRelationshipIntentUpdated(value),
+                        );
+                  },
+                ),
+              ],
 
               const SizedBox(height: OnboardingTheme.fieldToBottom),
             ],
           ),
         ),
       );
+
+  bool _shouldShowRelationshipGoals() => _platformPurpose == 'Dating & Romance';
 
   Widget _buildDropdown({
     required String value,

--- a/lib/features/onboarding/screens/enhanced_bio_screen.dart
+++ b/lib/features/onboarding/screens/enhanced_bio_screen.dart
@@ -37,10 +37,10 @@ class _EnhancedBioScreenState extends State<EnhancedBioScreen> {
 
   @override
   Widget build(BuildContext context) => OnboardingTheme.constrainedContent(
-      child: SingleChildScrollView(
-        keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-        padding: OnboardingTheme.pagePadding,
-        child: Column(
+        child: SingleChildScrollView(
+          keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+          padding: OnboardingTheme.pagePadding,
+          child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text('Tell your story', style: OnboardingTheme.titleStyle),

--- a/lib/features/onboarding/screens/enhanced_bio_screen.dart
+++ b/lib/features/onboarding/screens/enhanced_bio_screen.dart
@@ -37,9 +37,10 @@ class _EnhancedBioScreenState extends State<EnhancedBioScreen> {
 
   @override
   Widget build(BuildContext context) => OnboardingTheme.constrainedContent(
-        child: SingleChildScrollView(
-          padding: OnboardingTheme.pagePadding,
-          child: Column(
+      child: SingleChildScrollView(
+        keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+        padding: OnboardingTheme.pagePadding,
+        child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text('Tell your story', style: OnboardingTheme.titleStyle),
@@ -51,6 +52,7 @@ class _EnhancedBioScreenState extends State<EnhancedBioScreen> {
               const SizedBox(height: OnboardingTheme.subtitleToField),
               TextField(
                 controller: _bioController,
+                onTapOutside: (_) => FocusScope.of(context).unfocus(),
                 style: OnboardingTheme.fieldTextStyle.copyWith(height: 1.5),
                 maxLines: 8,
                 maxLength: _maxLength,

--- a/lib/features/onboarding/screens/enhanced_photo_upload_screen.dart
+++ b/lib/features/onboarding/screens/enhanced_photo_upload_screen.dart
@@ -63,7 +63,7 @@ class _EnhancedPhotoUploadScreenState extends State<EnhancedPhotoUploadScreen> {
             Text('Add your best photos', style: OnboardingTheme.titleStyle),
             const SizedBox(height: OnboardingTheme.titleToSubtitle),
             Text(
-              'Upload at least 1 photo. Profiles with 3+ photos get more matches.',
+              'Add at least 1 photo to continue. Profiles with 3+ photos get more matches.',
               style: OnboardingTheme.subtitleStyle,
             ),
             const SizedBox(height: 8),
@@ -100,7 +100,7 @@ class _EnhancedPhotoUploadScreenState extends State<EnhancedPhotoUploadScreen> {
                 );
               }),
             ),
-            const SizedBox(height: OnboardingTheme.fieldToBottom),
+            const SizedBox(height: 16),
           ],
         ),
       ),
@@ -147,16 +147,16 @@ class _EnhancedPhotoUploadScreenState extends State<EnhancedPhotoUploadScreen> {
                   ),
                 if (isMainPhoto && photo != null)
                   Positioned(
-                    top: 8,
-                    left: 8,
+                    top: 10,
+                    left: 10,
                     child: Container(
                       padding: const EdgeInsets.symmetric(
-                        horizontal: 8,
+                        horizontal: 10,
                         vertical: 4,
                       ),
                       decoration: BoxDecoration(
                         color: OnboardingTheme.primaryGreen,
-                        borderRadius: BorderRadius.circular(12),
+                        borderRadius: BorderRadius.circular(14),
                       ),
                       child: Row(
                         mainAxisSize: MainAxisSize.min,
@@ -166,7 +166,7 @@ class _EnhancedPhotoUploadScreenState extends State<EnhancedPhotoUploadScreen> {
                           Text(
                             'Main',
                             style: GoogleFonts.montserrat(
-                              fontSize: 11,
+                              fontSize: 10.5,
                               fontWeight: FontWeight.w600,
                               color: Colors.white,
                             ),
@@ -177,24 +177,26 @@ class _EnhancedPhotoUploadScreenState extends State<EnhancedPhotoUploadScreen> {
                   ),
                 if (photo != null)
                   Positioned(
-                    top: 8,
-                    right: 8,
-                    child: GestureDetector(
+                    top: 10,
+                    right: 10,
+                    child: InkWell(
+                      borderRadius: BorderRadius.circular(16),
                       onTap: () => _removePhoto(index),
                       child: Container(
                         width: OnboardingTheme.minTapTarget,
                         height: OnboardingTheme.minTapTarget,
-                        alignment: Alignment.topRight,
+                        alignment: Alignment.center,
                         child: Container(
-                          padding: const EdgeInsets.all(6),
+                          width: 32,
+                          height: 32,
                           decoration: BoxDecoration(
-                            color: Colors.black.withValues(alpha: 0.7),
+                            color: Colors.black.withValues(alpha: 0.72),
                             shape: BoxShape.circle,
                           ),
                           child: const Icon(
                             Icons.close,
                             color: Colors.white,
-                            size: 16,
+                            size: 18,
                           ),
                         ),
                       ),

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,7 +15,7 @@ sonar.tests=test,integration_test
 sonar.sourceEncoding=UTF-8
 
 # Exclusions - files to ignore during analysis
-sonar.exclusions=**/*.g.dart,**/*.freezed.dart,**/*.gr.dart,**/*.generated.dart,**/*_old.dart,build/**,coverage/**,**/*.md
+sonar.exclusions=**/*.g.dart,**/*.freezed.dart,**/*.gr.dart,**/*.generated.dart,**/*_old.dart,build/**,coverage/**,**/*.md,**/firebase_options*.dart
 
 # Test exclusions
 sonar.test.exclusions=**/*_test.dart

--- a/test/features/auth/google_login_bloc_test.dart
+++ b/test/features/auth/google_login_bloc_test.dart
@@ -116,6 +116,32 @@ void main() {
     );
 
     blocTest<GoogleLoginBloc, GoogleLoginStates>(
+      'emits [GoogleLoginLoading, GoogleLoginSuccess] when ensureUserDocument is permission-denied',
+      build: () {
+        when(() => mockRepo.signInWithGoogle()).thenAnswer(
+          (_) async => MockUser(uid: 'uid-1', displayName: 'Test'),
+        );
+        when(() => mockRepo.ensureUserDocument(any())).thenThrow(
+          FirebaseException(
+            plugin: 'cloud_firestore',
+            code: 'permission-denied',
+            message: 'The caller does not have permission',
+          ),
+        );
+        return GoogleLoginBloc(repository: mockRepo);
+      },
+      act: (bloc) => bloc.add(const GoogleLoginRequested()),
+      expect: () => [
+        GoogleLoginLoading(),
+        isA<GoogleLoginSuccess>(),
+      ],
+      verify: (_) {
+        verify(() => mockRepo.signInWithGoogle()).called(1);
+        verify(() => mockRepo.ensureUserDocument(any())).called(1);
+      },
+    );
+
+    blocTest<GoogleLoginBloc, GoogleLoginStates>(
       'emits [GoogleLoginLoading, GoogleLoginFailed] when ensureUserDocument throws after successful sign-in',
       build: () {
         when(() => mockRepo.signInWithGoogle()).thenAnswer(


### PR DESCRIPTION
## Summary
Merges auth and onboarding hardening from `fix/auth-onboarding-findings` into `develop`.

## Changes
- **Firestore rules:** Identity fields (`name`, `dateOfBirth`) are locked only when `onboardingCompleted` is true, so legacy `profileSetupComplete` / `isProfileComplete` no longer block first-time onboarding writes.
- **Onboarding repository:** Token refresh, permission-denied retry, legacy-compatible payload fallback, and sanitizer for rule-blocked fields.
- **AppEmptyView:** `SingleChildScrollView` + `mainAxisSize: min` to prevent RenderFlex overflow in fixed-height swipe area.
- **Auth / onboarding UI:** Google, email, phone, and enhanced onboarding screen updates; Google login bloc test adjustments.

## Deploy note
Firestore rules in this branch should be deployed to each Firebase project the app uses (e.g. `naijasingles-staging`, `naijasingles-74a75`) with `firebase deploy --only firestore:rules --project <id>`.


Made with [Cursor](https://cursor.com)