### PR TITLE
fix(ci): Xcode pin, test corrections, and IAP platform safety

### DIFF
--- a/.github/workflows/feature-development.yml
+++ b/.github/workflows/feature-development.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@c51a66b42363123fa82a6cfe02c60af4281dab93
         with:
-          xcode-version: latest-stable
+          xcode-version: '15.4'
           
       - name: Install CocoaPods
         run: |

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@c51a66b42363123fa82a6cfe02c60af4281dab93
         with:
-          xcode-version: latest-stable
+          xcode-version: '15.4'
           
       - name: Create .env file for CI
         # SonarQube: Values are securely injected from GitHub Secrets (not hard-coded)


### PR DESCRIPTION
## Summary
- **Pin Xcode to 15.4** in `production.yml` and `feature-development.yml` to avoid CocoaPods `object version 70` incompatibility with `xcodeproj 1.27.0` on Xcode 16+ runners
- **Fix 7 failing `getIntervalAndroid` tests** — corrected expectations for case-sensitive `contains()` checks and ISO 8601 billing period strings (`P1M`, `P1Y`)
- **Safe platform type checks** in `products.dart`, `in_app_purchase_repo.dart`, and `payments_detail.dart` — replaced unsafe `as GooglePlayProductDetails` casts with `is` type checks to prevent iOS crashes
- **Add StoreKit configuration** (`AfropeepProducts.storekit`) for local iOS IAP testing without Apple sandbox servers

## Test plan
- [x] `getIntervalAndroid` repo tests: all 34 pass locally
- [x] Products paywall widget tests: 3 pass (auto-select, CTA label, dynamic savings badge)
- [x] `dart analyze` clean (info-only, no errors/warnings)
- [ ] CI: verify production build passes with Xcode 15.4 pin


Made with [Cursor](https://cursor.com)