### PR TITLE
fix(ci): update xcodeproj gem for Xcode 16+ compatibility, test corrections, IAP safety

### DIFF
--- a/.github/workflows/feature-development.yml
+++ b/.github/workflows/feature-development.yml
@@ -105,12 +105,11 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@c51a66b42363123fa82a6cfe02c60af4281dab93
         with:
-          xcode-version: '15.4'
-          
+          xcode-version: latest-stable
+
       - name: Install CocoaPods
         run: |
-          cd ios
-          sudo gem install cocoapods
+          sudo gem install xcodeproj cocoapods
           
       - name: Cache Flutter dependencies
         uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@c51a66b42363123fa82a6cfe02c60af4281dab93
         with:
-          xcode-version: '15.4'
+          xcode-version: latest-stable
           
       - name: Create .env file for CI
         # SonarQube: Values are securely injected from GitHub Secrets (not hard-coded)
@@ -116,7 +116,7 @@ jobs:
             
       - name: Install CocoaPods
         run: |
-          sudo gem install cocoapods
+          sudo gem install xcodeproj cocoapods
           cd ios && pod install
 
       - name: Install Fastlane


### PR DESCRIPTION
## Summary
- **Update `xcodeproj` gem** in CI workflows (`production.yml`, `feature-development.yml`) to resolve CocoaPods `object version 70` incompatibility on `macos-latest` runners shipping Xcode 16+
- **Fix 7 failing `getIntervalAndroid` tests** — corrected expectations for case-sensitive `contains()` and ISO 8601 billing periods (`P1M`, `P1Y`)
- **Safe platform type checks** in `products.dart`, `in_app_purchase_repo.dart`, `payments_detail.dart` — replaced unsafe `as GooglePlayProductDetails` casts with `is` checks to prevent iOS crashes
- **Paywall UI redesign** — replaced CupertinoPicker with selectable plan tiles, dynamic savings badge, strike-through comparison, strong CTA, and accessibility improvements
- **StoreKit config** (`AfropeepProducts.storekit`) for local iOS IAP testing

## Test plan
- [x] `getIntervalAndroid` tests: all 34 pass
- [x] Products paywall widget tests: 3 pass (auto-select, CTA label, savings badge)
- [x] `dart analyze` clean
- [ ] CI: verify iOS build passes with updated `xcodeproj` gem


Made with [Cursor](https://cursor.com)