### PR TITLE
feat(chat): images, typing, replies, search, and safety

### DIFF
--- a/lib/features/chat_shared/models/chat_message_view_model.dart
+++ b/lib/features/chat_shared/models/chat_message_view_model.dart
@@ -12,10 +12,12 @@ class ChatMessageViewModel {
     this.isRead = false,
     this.isSystemMessage = false,
     this.showReadReceipt = false,
+    this.imageUrl,
   });
 
   final String id;
   final String text;
+  final String? imageUrl;
   final DateTime timestamp;
   final String senderId;
   final bool isOwnMessage;

--- a/lib/features/chat_shared/ui/widgets/chat_bubble.dart
+++ b/lib/features/chat_shared/ui/widgets/chat_bubble.dart
@@ -105,7 +105,20 @@ class ChatBubble extends StatelessWidget {
               padding: const EdgeInsets.only(bottom: 4),
               child: Text(message.senderName!, style: tokens.senderNameStyle()),
             ),
-          Text(message.text, style: tokens.messageStyle(isOwn: isOwn)),
+          if (message.imageUrl != null) ...[
+            ClipRRect(
+              borderRadius: BorderRadius.circular(12),
+              child: Image.network(
+                message.imageUrl!,
+                width: 220,
+                fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) => const Icon(Icons.broken_image),
+              ),
+            ),
+            if (message.text.isNotEmpty) const SizedBox(height: 6),
+          ],
+          if (message.text.isNotEmpty)
+            Text(message.text, style: tokens.messageStyle(isOwn: isOwn)),
           const SizedBox(height: 6),
           _timestampRow(tokens, isOwn),
         ],

--- a/lib/features/chat_shared/ui/widgets/chat_composer.dart
+++ b/lib/features/chat_shared/ui/widgets/chat_composer.dart
@@ -21,11 +21,15 @@ class ChatComposer extends StatelessWidget {
     this.submitOnEnter = false,
     this.maxLines = 4,
     this.hintText = 'Type a message...',
+    this.showAttachButton = false,
+    this.onAttachTap,
   });
 
   final TextEditingController controller;
   final VoidCallback onSend;
   final bool hasText;
+  final bool showAttachButton;
+  final VoidCallback? onAttachTap;
   final bool showEmojiButton;
   final VoidCallback? onEmojiTap;
   final bool animateSendButton;
@@ -53,6 +57,11 @@ class ChatComposer extends StatelessWidget {
       child: SafeArea(
         child: Row(
           children: [
+            if (showAttachButton)
+              IconButton(
+                icon: const Icon(Icons.image_outlined, color: Colors.grey),
+                onPressed: onAttachTap,
+              ),
             if (showEmojiButton)
               IconButton(
                 icon: const Icon(

--- a/lib/features/messages/chat_thread_screen.dart
+++ b/lib/features/messages/chat_thread_screen.dart
@@ -6,10 +6,12 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:image_picker/image_picker.dart';
 
 import '../../common/constants/app_colors.dart';
 import '../../common/widgets/state_views/state_views.dart';
 import '../../models/user_model.dart';
+import '../../services/media_sharing_service.dart';
 import '../../services/settings_service.dart';
 import '../chat_shared/models/chat_message_view_model.dart';
 import '../chat_shared/ui/widgets/chat_bubble.dart';
@@ -17,6 +19,7 @@ import '../chat_shared/ui/widgets/chat_composer.dart';
 import '../dating/screens/user_detail_screen.dart';
 import 'message_model.dart';
 import 'services/chat_service.dart';
+import 'widgets/pre_meet_safety_sheet.dart';
 
 class ChatThreadScreen extends StatefulWidget {
   const ChatThreadScreen({
@@ -39,8 +42,15 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
   final TextEditingController _messageController = TextEditingController();
   final ScrollController _scrollController = ScrollController();
   final ChatService _chatService = ChatService();
+  final MediaSharingService _mediaService = MediaSharingService();
+  final ImagePicker _imagePicker = ImagePicker();
   String? _currentUserId;
   bool _hasText = false;
+  Timer? _typingDebounce;
+  bool _showSearch = false;
+  String _searchQuery = '';
+  String? _replyToMessageId;
+  String? _replyPreview;
 
   @override
   void initState() {
@@ -55,6 +65,11 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
           _hasText = hasText;
         });
       }
+      _typingDebounce?.cancel();
+      unawaited(_chatService.setTyping(widget.threadId, isTyping: true));
+      _typingDebounce = Timer(const Duration(seconds: 2), () {
+        unawaited(_chatService.setTyping(widget.threadId, isTyping: false));
+      });
     });
 
     unawaited(_chatService.markThreadAsRead(widget.threadId));
@@ -67,6 +82,8 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
 
   @override
   void dispose() {
+    _typingDebounce?.cancel();
+    unawaited(_chatService.setTyping(widget.threadId, isTyping: false));
     _messageController.dispose();
     _scrollController.dispose();
     super.dispose();
@@ -81,6 +98,25 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
           curve: Curves.easeOut,
         ),
       );
+    }
+  }
+
+  Future<void> _pickAndSendImage() async {
+    try {
+      final picked = await _imagePicker.pickImage(
+        source: ImageSource.gallery,
+        imageQuality: 85,
+      );
+      if (picked == null) return;
+      await _mediaService.shareImage(
+        threadId: widget.threadId,
+        imagePath: picked.path,
+      );
+      if (mounted) {
+        Future.delayed(const Duration(milliseconds: 100), _scrollToBottom);
+      }
+    } on Object catch (error) {
+      _showErrorSnackBar('Could not send image: $error');
     }
   }
 
@@ -99,7 +135,17 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
     }
 
     try {
-      final success = await _chatService.sendMessage(widget.threadId, text);
+      final success = await _chatService.sendMessage(
+        widget.threadId,
+        text,
+        replyToMessageId: _replyToMessageId,
+      );
+      if (success) {
+        setState(() {
+          _replyToMessageId = null;
+          _replyPreview = null;
+        });
+      }
       if (success) {
         _messageController.clear();
         Future.delayed(const Duration(milliseconds: 100), _scrollToBottom);
@@ -157,12 +203,24 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
                       ),
                       overflow: TextOverflow.ellipsis,
                     ),
-                    Text(
-                      'Tap to view profile',
-                      style: GoogleFonts.montserrat(
-                        fontSize: 11,
-                        color: AppColors.primaryGreen,
+                    StreamBuilder<List<String>>(
+                      stream: _chatService.watchOtherUsersTyping(
+                        widget.threadId,
                       ),
+                      builder: (context, snapshot) {
+                        final typing = snapshot.data?.isNotEmpty ?? false;
+                        return Text(
+                          typing ? 'typing...' : 'Tap to view profile',
+                          style: GoogleFonts.montserrat(
+                            fontSize: 11,
+                            color: typing
+                                ? AppColors.primaryGreen
+                                : AppColors.textSecondary,
+                            fontStyle:
+                                typing ? FontStyle.italic : FontStyle.normal,
+                          ),
+                        );
+                      },
                     ),
                   ],
                 ),
@@ -171,6 +229,13 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
           ),
         ),
         actions: [
+          IconButton(
+            icon: Icon(
+              _showSearch ? Icons.close : Icons.search,
+              color: AppColors.primaryGreen,
+            ),
+            onPressed: () => setState(() => _showSearch = !_showSearch),
+          ),
           IconButton(
             icon: const Icon(Icons.info_outline, color: AppColors.primaryGreen),
             onPressed: _showUserProfile,
@@ -188,9 +253,16 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
                 case 'clear':
                   _showClearChatDialog();
                   break;
+                case 'safety':
+                  unawaited(PreMeetSafetySheet.show(context));
+                  break;
               }
             },
             itemBuilder: (context) => [
+              const PopupMenuItem(
+                value: 'safety',
+                child: Text('Safety tips'),
+              ),
               const PopupMenuItem(
                 value: 'block',
                 child: Text(
@@ -218,6 +290,17 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
       ),
       body: Column(
         children: [
+          if (_showSearch)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+              child: TextField(
+                decoration: const InputDecoration(
+                  hintText: 'Search in conversation',
+                  prefixIcon: Icon(Icons.search),
+                ),
+                onChanged: (value) => setState(() => _searchQuery = value),
+              ),
+            ),
           // Chat messages
           Expanded(
             child: StreamBuilder<List<Message>>(
@@ -235,7 +318,13 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
                   );
                 }
 
-                final messages = snapshot.data ?? [];
+                var messages = snapshot.data ?? [];
+                if (_searchQuery.isNotEmpty) {
+                  final q = _searchQuery.toLowerCase();
+                  messages = messages
+                      .where((m) => m.text.toLowerCase().contains(q))
+                      .toList();
+                }
 
                 if (messages.isEmpty) {
                   return AppEmptyView(
@@ -273,13 +362,17 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
                       senderAvatarUrl: isMe ? null : widget.avatarUrl,
                       isRead: message.isRead,
                       showReadReceipt: true,
+                      imageUrl: message.imageUrl,
                     );
 
                     return Column(
                       children: [
                         if (showDateSeparator)
                           _buildDateSeparator(message.timestamp),
-                        ChatBubble(message: vm),
+                        GestureDetector(
+                          onLongPress: () => _showMessageActions(message.id),
+                          child: ChatBubble(message: vm),
+                        ),
                       ],
                     );
                   },
@@ -288,10 +381,35 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
             ),
           ),
 
+          if (_replyPreview != null)
+            Container(
+              color: Colors.grey.shade100,
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Replying: $_replyPreview',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    onPressed: () => setState(() {
+                      _replyToMessageId = null;
+                      _replyPreview = null;
+                    }),
+                  ),
+                ],
+              ),
+            ),
           ChatComposer(
             controller: _messageController,
             onSend: _sendMessage,
             hasText: _hasText,
+            showAttachButton: true,
+            onAttachTap: _pickAndSendImage,
             showEmojiButton: true,
             onEmojiTap: _showEmojiPicker,
           ),
@@ -1096,6 +1214,44 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
   }
 
   // Show error snackbar
+  Future<void> _showMessageActions(String messageId) async {
+    final action = await showModalBottomSheet<String>(
+      context: context,
+      builder: (ctx) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.reply),
+              title: const Text('Reply'),
+              onTap: () => Navigator.pop(ctx, 'reply'),
+            ),
+            ListTile(
+              leading: const Icon(Icons.emoji_emotions_outlined),
+              title: const Text('React'),
+              onTap: () => Navigator.pop(ctx, 'react'),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (!mounted || action == null) return;
+    if (action == 'reply') {
+      setState(() {
+        _replyToMessageId = messageId;
+        _replyPreview = _messageController.text.isNotEmpty
+            ? _messageController.text
+            : 'message';
+      });
+    } else if (action == 'react') {
+      await _chatService.addReaction(
+        threadId: widget.threadId,
+        messageId: messageId,
+        emoji: '❤️',
+      );
+    }
+  }
+
   void _showErrorSnackBar(String message) {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(

--- a/lib/features/messages/message_model.dart
+++ b/lib/features/messages/message_model.dart
@@ -5,12 +5,16 @@ class Message {
     required this.text,
     required this.timestamp,
     required this.isRead,
+    this.imageUrl,
+    this.messageType = 'text',
   });
   final String id;
   final String senderId;
   final String text;
   final DateTime timestamp;
   final bool isRead;
+  final String? imageUrl;
+  final String messageType;
 }
 
 class MessageThreadInfo {

--- a/lib/features/messages/services/chat_service.dart
+++ b/lib/features/messages/services/chat_service.dart
@@ -181,7 +181,11 @@ class ChatService {
   Future<void> setTyping(String threadId, {required bool isTyping}) async {
     final uid = currentUserId;
     if (uid == null) return;
-    await _chatThreadsCollection.doc(threadId).collection('typing').doc(uid).set(
+    await _chatThreadsCollection
+        .doc(threadId)
+        .collection('typing')
+        .doc(uid)
+        .set(
       {
         'isTyping': isTyping,
         'updatedAt': FieldValue.serverTimestamp(),
@@ -297,8 +301,7 @@ class ChatService {
             'timestamp': FieldValue.serverTimestamp(),
             'read': false,
             'deliveredAt': FieldValue.serverTimestamp(),
-            if (replyToMessageId != null)
-              'replyToMessageId': replyToMessageId,
+            if (replyToMessageId != null) 'replyToMessageId': replyToMessageId,
           };
 
           // Add the message
@@ -451,8 +454,8 @@ class ChatService {
                 text: data['text'] ?? '',
                 timestamp: parseDateTime(data['timestamp']),
                 isRead: data['read'] ?? false,
-                imageUrl: data['imageUrl'] as String? ??
-                    data['mediaUrl'] as String?,
+                imageUrl:
+                    data['imageUrl'] as String? ?? data['mediaUrl'] as String?,
                 messageType: data['messageType'] as String? ?? 'text',
               );
             }).toList(),
@@ -592,7 +595,8 @@ class ChatService {
             text: data['text'] ?? '',
             timestamp: parseDateTime(data['timestamp']),
             isRead: data['read'] ?? false,
-            imageUrl: data['imageUrl'] as String? ?? data['mediaUrl'] as String?,
+            imageUrl:
+                data['imageUrl'] as String? ?? data['mediaUrl'] as String?,
             messageType: data['messageType'] as String? ?? 'text',
           );
         }).toList();

--- a/lib/features/messages/services/chat_service.dart
+++ b/lib/features/messages/services/chat_service.dart
@@ -177,7 +177,67 @@ class ChatService {
     }
   }
 
-  Future<bool> sendMessage(String threadId, String text) =>
+  /// Updates typing indicator for the current user in a thread.
+  Future<void> setTyping(String threadId, {required bool isTyping}) async {
+    final uid = currentUserId;
+    if (uid == null) return;
+    await _chatThreadsCollection.doc(threadId).collection('typing').doc(uid).set(
+      {
+        'isTyping': isTyping,
+        'updatedAt': FieldValue.serverTimestamp(),
+      },
+      SetOptions(merge: true),
+    );
+  }
+
+  /// Emits user IDs currently typing (excluding current user).
+  Stream<List<String>> watchOtherUsersTyping(String threadId) {
+    final uid = currentUserId;
+    if (uid == null) return const Stream<List<String>>.empty();
+
+    return _chatThreadsCollection
+        .doc(threadId)
+        .collection('typing')
+        .snapshots()
+        .map((snapshot) {
+      final now = DateTime.now();
+      return snapshot.docs
+          .where((doc) => doc.id != uid)
+          .where((doc) {
+            final data = doc.data();
+            if (data['isTyping'] != true) return false;
+            final updatedAt = parseDateTime(data['updatedAt']);
+            return now.difference(updatedAt).inSeconds < 8;
+          })
+          .map((doc) => doc.id)
+          .toList();
+    });
+  }
+
+  Future<void> addReaction({
+    required String threadId,
+    required String messageId,
+    required String emoji,
+  }) async {
+    final uid = currentUserId;
+    if (uid == null) return;
+    await _chatThreadsCollection
+        .doc(threadId)
+        .collection('messages')
+        .doc(messageId)
+        .set(
+      {
+        'reactions': {uid: emoji},
+      },
+      SetOptions(merge: true),
+    );
+  }
+
+  Future<bool> sendMessage(
+    String threadId,
+    String text, {
+    String? replyToMessageId,
+  }) =>
       PerformanceMonitor.measure('send_message', () async {
         try {
           if (currentUserId == null) return false;
@@ -233,8 +293,12 @@ class ChatService {
           final messageData = {
             'senderId': currentUserId,
             'text': text.trim(),
+            'messageType': 'text',
             'timestamp': FieldValue.serverTimestamp(),
             'read': false,
+            'deliveredAt': FieldValue.serverTimestamp(),
+            if (replyToMessageId != null)
+              'replyToMessageId': replyToMessageId,
           };
 
           // Add the message
@@ -387,6 +451,9 @@ class ChatService {
                 text: data['text'] ?? '',
                 timestamp: parseDateTime(data['timestamp']),
                 isRead: data['read'] ?? false,
+                imageUrl: data['imageUrl'] as String? ??
+                    data['mediaUrl'] as String?,
+                messageType: data['messageType'] as String? ?? 'text',
               );
             }).toList(),
           );
@@ -525,6 +592,8 @@ class ChatService {
             text: data['text'] ?? '',
             timestamp: parseDateTime(data['timestamp']),
             isRead: data['read'] ?? false,
+            imageUrl: data['imageUrl'] as String? ?? data['mediaUrl'] as String?,
+            messageType: data['messageType'] as String? ?? 'text',
           );
         }).toList();
         if (!qualityTracked && latestMessages!.length >= 2) {

--- a/lib/features/messages/widgets/pre_meet_safety_sheet.dart
+++ b/lib/features/messages/widgets/pre_meet_safety_sheet.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../../common/constants/app_colors.dart';
+import '../../../common/routes/route_name.dart';
+
+/// Safety tips shown before sharing contact details or meeting offline.
+class PreMeetSafetySheet extends StatelessWidget {
+  const PreMeetSafetySheet({super.key});
+
+  static Future<void> show(BuildContext context) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (_) => const PreMeetSafetySheet(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) => SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Material(
+            borderRadius: BorderRadius.circular(20),
+            child: Padding(
+              padding: const EdgeInsets.all(20),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    'Stay safe when meeting',
+                    style: GoogleFonts.montserrat(
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    'Meet in public, tell a friend your plans, and trust your instincts. '
+                    'You can report or block anyone from their profile or chat menu.',
+                    style: GoogleFonts.montserrat(height: 1.4),
+                  ),
+                  const SizedBox(height: 16),
+                  TextButton(
+                    onPressed: () {
+                      Navigator.pop(context);
+                      Navigator.pushNamed(context, RouteName.safetyCenter);
+                    },
+                    child: const Text('Open Safety Center'),
+                  ),
+                  ElevatedButton(
+                    onPressed: () => Navigator.pop(context),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.primaryGreen,
+                      foregroundColor: Colors.white,
+                    ),
+                    child: const Text('Got it'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+}

--- a/lib/services/media_sharing_service.dart
+++ b/lib/services/media_sharing_service.dart
@@ -26,8 +26,7 @@ class MediaSharingService {
   FirebaseStorage? _storage;
   final ImagePicker _imagePicker = ImagePicker();
 
-  FirebaseStorage get _storageInstance =>
-      _storage ?? FirebaseStorage.instance;
+  FirebaseStorage get _storageInstance => _storage ?? FirebaseStorage.instance;
 
   /// Share image in chat
   Future<MediaMessage> shareImage({

--- a/lib/services/media_sharing_service.dart
+++ b/lib/services/media_sharing_service.dart
@@ -23,8 +23,11 @@ class MediaSharingService {
 
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
   final FirebaseAuth _auth = FirebaseAuth.instance;
-  final FirebaseStorage _storage = FirebaseStorage.instance;
+  FirebaseStorage? _storage;
   final ImagePicker _imagePicker = ImagePicker();
+
+  FirebaseStorage get _storageInstance =>
+      _storage ?? FirebaseStorage.instance;
 
   /// Share image in chat
   Future<MediaMessage> shareImage({
@@ -332,7 +335,7 @@ class MediaSharingService {
     try {
       final file = File(imagePath);
       final fileName = 'images/${DateTime.now().millisecondsSinceEpoch}.jpg';
-      final ref = _storage.ref().child(fileName);
+      final ref = _storageInstance.ref().child(fileName);
 
       final uploadTask = await ref.putFile(file);
       return await uploadTask.ref.getDownloadURL();
@@ -347,7 +350,7 @@ class MediaSharingService {
     try {
       final file = File(videoPath);
       final fileName = 'videos/${DateTime.now().millisecondsSinceEpoch}.mp4';
-      final ref = _storage.ref().child(fileName);
+      final ref = _storageInstance.ref().child(fileName);
 
       final uploadTask = await ref.putFile(file);
       return await uploadTask.ref.getDownloadURL();
@@ -362,7 +365,7 @@ class MediaSharingService {
     try {
       final file = File(audioPath);
       final fileName = 'audio/${DateTime.now().millisecondsSinceEpoch}.m4a';
-      final ref = _storage.ref().child(fileName);
+      final ref = _storageInstance.ref().child(fileName);
 
       final uploadTask = await ref.putFile(file);
       return await uploadTask.ref.getDownloadURL();
@@ -378,7 +381,7 @@ class MediaSharingService {
       final file = File(filePath);
       final fileName =
           'files/${DateTime.now().millisecondsSinceEpoch}_${file.path.split('/').last}';
-      final ref = _storage.ref().child(fileName);
+      final ref = _storageInstance.ref().child(fileName);
 
       final uploadTask = await ref.putFile(file);
       return await uploadTask.ref.getDownloadURL();

--- a/test/features/messages/chat_reply_payload_test.dart
+++ b/test/features/messages/chat_reply_payload_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+
+/// Documents expected Firestore payload shape for reply messages.
+Map<String, dynamic> buildTextMessagePayload({
+  required String senderId,
+  required String text,
+  String? replyToMessageId,
+}) {
+  return {
+    'senderId': senderId,
+    'text': text.trim(),
+    'messageType': 'text',
+    'read': false,
+    if (replyToMessageId != null) 'replyToMessageId': replyToMessageId,
+  };
+}
+
+void main() {
+  test('reply payload includes parent message id', () {
+    final payload = buildTextMessagePayload(
+      senderId: 'user_a',
+      text: 'Sounds good!',
+      replyToMessageId: 'msg_parent',
+    );
+    expect(payload['replyToMessageId'], 'msg_parent');
+    expect(payload['messageType'], 'text');
+  });
+
+  test('plain text payload omits reply field', () {
+    final payload = buildTextMessagePayload(
+      senderId: 'user_a',
+      text: 'Hello',
+    );
+    expect(payload.containsKey('replyToMessageId'), false);
+  });
+}


### PR DESCRIPTION
## Summary
- Chat **image attach** via `MediaSharingService`
- **Typing** indicators under `chatThreads/{id}/typing/{uid}`
- **Reply** bar + long-press react/reply
- In-thread **search** and **pre-meet safety** sheet

## Security (stacked with #185)
Client typing UX ships here; **Firestore enforcement** lands in #185. That PR removes a duplicate permissive `typing` rule so only **thread participants** can read/write typing docs—presence is not world-readable. Merge #185 before deploy if you enable typing in production.

## Test plan
- [ ] Send image in thread; appears in bubble
- [ ] Typing doc updates while composing
- [ ] Reply shows quoted parent id in payload
- [ ] `flutter test test/features/messages/chat_reply_payload_test.dart`

**Stack:** PR 3 of 5 — base: phase 2