### PR TITLE
Consolidate auth, messages, storage, and corrected security rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -133,6 +133,11 @@ service cloud.firestore {
         // Only notification owner can access these documents from client SDK.
         allow read, write: if request.auth != null && request.auth.uid == userId;
       }
+
+      // Profile verification metadata — owner only.
+      match /verification/{verificationId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
     }
 
     // Super Likes collection - for premium super like functionality
@@ -818,6 +823,20 @@ service cloud.firestore {
       allow read: if request.auth != null &&
                    resource.data.userId == request.auth.uid;
       allow update, delete: if false;
+    }
+
+    // Voice/video call sessions — participants only.
+    function isCallParticipant(data) {
+      return data.keys().hasAny(['participantIds'])
+        && data.participantIds is list
+        && request.auth.uid in data.participantIds;
+    }
+
+    match /calls/{callId} {
+      allow read, update, delete: if request.auth != null &&
+                                     isCallParticipant(resource.data);
+      allow create: if request.auth != null &&
+                     isCallParticipant(request.resource.data);
     }
 
     // Block any other access not explicitly allowed above

--- a/functions/package.json
+++ b/functions/package.json
@@ -10,6 +10,7 @@
     "deploy": "npm run build && firebase deploy --only functions",
     "logs": "firebase functions:log",
     "test": "jest",
+    "test:rules": "firebase emulators:exec --only firestore,storage \"npm test -- --testPathPattern=rules.test.ts\"",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "lint": "eslint --ext .ts .",
@@ -26,6 +27,7 @@
     "google-auth-library": "^9.15.1"
   },
   "devDependencies": {
+    "@firebase/rules-unit-testing": "^4.0.1",
     "@types/jest": "^29.5.0",
     "@types/node": "^22.19.17",
     "@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/functions/test/firestore.rules.test.ts
+++ b/functions/test/firestore.rules.test.ts
@@ -1,0 +1,174 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+  RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+
+const PROJECT_ID = 'afropeep-rules-test';
+
+let testEnv: RulesTestEnvironment;
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: fs.readFileSync(
+        path.resolve(__dirname, '../../firestore.rules'),
+        'utf8',
+      ),
+      host: '127.0.0.1',
+      port: 8080,
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv.cleanup();
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+});
+
+describe('firestore.rules', () => {
+  test('premium user can update profile without changing entitlement fields', async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      await context.firestore().collection('users').doc('premium-user').set({
+        name: 'Premium User',
+        dateOfBirth: '1990-01-01',
+        isPremium: true,
+        subscriptionDate: '2026-01-01',
+        onboardingCompleted: true,
+        isDiscoverable: true,
+        isProfilePrivate: false,
+        isDeleted: false,
+        accountStatus: 'active',
+      });
+    });
+
+    const db = testEnv.authenticatedContext('premium-user').firestore();
+    await assertSucceeds(
+      db.collection('users').doc('premium-user').update({
+        bio: 'Updated bio',
+      }),
+    );
+  });
+
+  test('premium user cannot self-grant premium entitlement', async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      await context.firestore().collection('users').doc('free-user').set({
+        name: 'Free User',
+        dateOfBirth: '1995-05-05',
+        isPremium: false,
+        onboardingCompleted: true,
+        isDiscoverable: true,
+        isProfilePrivate: false,
+        isDeleted: false,
+        accountStatus: 'active',
+      });
+    });
+
+    const db = testEnv.authenticatedContext('free-user').firestore();
+    await assertFails(
+      db.collection('users').doc('free-user').update({
+        isPremium: true,
+        subscriptionDate: '2026-06-01',
+      }),
+    );
+  });
+
+  test('legacy root verification field does not block profile reads', async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      await context.firestore().collection('users').doc('verified-user').set({
+        name: 'Verified User',
+        verification: {status: 'approved'},
+        isDiscoverable: true,
+        isProfilePrivate: false,
+        isDeleted: false,
+        accountStatus: 'active',
+      });
+    });
+
+    const db = testEnv.authenticatedContext('other-user').firestore();
+    await assertSucceeds(db.collection('users').doc('verified-user').get());
+  });
+
+  test('owner can write verification subcollection metadata', async () => {
+    const db = testEnv.authenticatedContext('owner-user').firestore();
+    await assertSucceeds(
+      db
+        .collection('users')
+        .doc('owner-user')
+        .collection('verification')
+        .doc('current')
+        .set({
+          status: 'pending',
+          imageUrl: 'https://example.com/verification.jpg',
+        }),
+    );
+  });
+
+  test('non-owner cannot read verification subcollection metadata', async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      await context
+        .firestore()
+        .collection('users')
+        .doc('owner-user')
+        .collection('verification')
+        .doc('current')
+        .set({status: 'pending'});
+    });
+
+    const db = testEnv.authenticatedContext('other-user').firestore();
+    await assertFails(
+      db
+        .collection('users')
+        .doc('owner-user')
+        .collection('verification')
+        .doc('current')
+        .get(),
+    );
+  });
+
+  test('call create validates request.resource participantIds', async () => {
+    const db = testEnv.authenticatedContext('caller-a').firestore();
+    await assertSucceeds(
+      db.collection('calls').doc('call-1').set({
+        participantIds: ['caller-a', 'caller-b'],
+        status: 'ringing',
+      }),
+    );
+  });
+
+  test('call create fails when caller is not in participantIds', async () => {
+    const db = testEnv.authenticatedContext('caller-a').firestore();
+    await assertFails(
+      db.collection('calls').doc('call-2').set({
+        participantIds: ['caller-b', 'caller-c'],
+        status: 'ringing',
+      }),
+    );
+  });
+
+  test('non-participant cannot read call session', async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      await context.firestore().collection('calls').doc('call-3').set({
+        participantIds: ['caller-a', 'caller-b'],
+        status: 'active',
+      });
+    });
+
+    const db = testEnv.authenticatedContext('intruder').firestore();
+    await assertFails(db.collection('calls').doc('call-3').get());
+  });
+
+  test('unknown top-level collection is denied', async () => {
+    const db = testEnv.authenticatedContext('any-user').firestore();
+    await assertFails(
+      db.collection('secretCollection').doc('doc-1').set({value: 1}),
+    );
+  });
+});

--- a/functions/test/storage.rules.test.ts
+++ b/functions/test/storage.rules.test.ts
@@ -1,0 +1,104 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+  RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+
+const PROJECT_ID = 'afropeep-storage-rules-test';
+
+let testEnv: RulesTestEnvironment;
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: fs.readFileSync(
+        path.resolve(__dirname, '../../firestore.rules'),
+        'utf8',
+      ),
+      host: '127.0.0.1',
+      port: 8080,
+    },
+    storage: {
+      rules: fs.readFileSync(
+        path.resolve(__dirname, '../../storage.rules'),
+        'utf8',
+      ),
+      host: '127.0.0.1',
+      port: 9199,
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv.cleanup();
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+  await testEnv.clearStorage();
+});
+
+describe('storage.rules', () => {
+  test('owner can upload verification image', async () => {
+    const storage = testEnv
+      .authenticatedContext('owner-user')
+      .storage()
+      .ref('verification/owner-user/selfie.jpg');
+
+    await assertSucceeds(
+      storage.put(new Uint8Array([1, 2, 3]), {
+        contentType: 'image/jpeg',
+      }) as unknown as Promise<void>,
+    );
+  });
+
+  test('non-owner cannot read verification image', async () => {
+    const ownerStorage = testEnv
+      .authenticatedContext('owner-user')
+      .storage()
+      .ref('verification/owner-user/selfie.jpg');
+    await ownerStorage.put(new Uint8Array([1, 2, 3]), {
+      contentType: 'image/jpeg',
+    });
+
+    const intruderStorage = testEnv
+      .authenticatedContext('other-user')
+      .storage()
+      .ref('verification/owner-user/selfie.jpg');
+
+    await assertFails(intruderStorage.getMetadata());
+  });
+
+  test('unauthenticated users cannot read profile photos', async () => {
+    const ownerStorage = testEnv
+      .authenticatedContext('owner-user')
+      .storage()
+      .ref('users/owner-user/profile.jpg');
+    await ownerStorage.put(new Uint8Array([1, 2, 3]), {
+      contentType: 'image/jpeg',
+    });
+
+    const guestStorage = testEnv.unauthenticatedContext().storage().ref(
+      'users/owner-user/profile.jpg',
+    );
+
+    await assertFails(guestStorage.getMetadata());
+  });
+
+  test('unknown storage path is denied', async () => {
+    const storage = testEnv
+      .authenticatedContext('any-user')
+      .storage()
+      .ref('secret/path/file.jpg');
+
+    await assertFails(
+      storage.put(new Uint8Array([1, 2, 3]), {
+        contentType: 'image/jpeg',
+      }) as unknown as Promise<void>,
+    );
+  });
+});

--- a/lib/features/auth/auth_status/bloc/authstatus_bloc.dart
+++ b/lib/features/auth/auth_status/bloc/authstatus_bloc.dart
@@ -6,7 +6,6 @@ import 'package:equatable/equatable.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import '../../../../common/constants/constants.dart';
 import '../../../../common/data/repo/phone_auth_repo.dart';
 import '../../../../services/secure_storage_service.dart';
 
@@ -22,7 +21,6 @@ class AuthstatusBloc extends Bloc<AuthstatusEvent, AuthstatusState> {
     on<LogoutEvent>(_logout);
   }
   final PhoneAuthRepository phoneAuthRepository;
-  final auth = firebaseAuthInstance;
 
 //for logout
   Future<void> _logout(LogoutEvent event, Emitter<AuthstatusState> emit) async {
@@ -61,7 +59,7 @@ class AuthstatusBloc extends Bloc<AuthstatusEvent, AuthstatusState> {
         log('Is signed in check: $issingedin');
 
         if (issingedin) {
-          final user = auth.currentUser;
+          final user = await phoneAuthRepository.getCurrentUser();
           if (user != null) {
             log('User signed in successfully: ${user.uid}');
             log("Phone number: ${user.phoneNumber ?? 'No phone number'}");

--- a/lib/features/messages/services/chat_service.dart
+++ b/lib/features/messages/services/chat_service.dart
@@ -639,13 +639,13 @@ class ChatService {
   // Threads involving blocked users are filtered out as defense in depth
   // (the block flow also deletes the thread document).
   Stream<List<MessageThreadInfo>> getChatThreadsStream() {
-    if (currentUserId == null) {
+    final userId = currentUserId;
+    if (userId == null) {
       return Stream.value([]);
     }
 
     return _chatThreadsCollection
-        .where('userIds', arrayContains: currentUserId)
-        .orderBy('lastUpdated', descending: true)
+        .where('userIds', arrayContains: userId)
         .snapshots()
         .handleError((error) {
       AppLogger.error('Error in getChatThreadsStream', error: error);
@@ -656,19 +656,19 @@ class ChatService {
         // thread document was not yet deleted (race condition / legacy data).
         final blockedSnapshot = await _firestore
             .collection('users')
-            .doc(currentUserId)
+            .doc(userId)
             .collection('blockedlist')
             .get();
         final blockedIds = blockedSnapshot.docs.map((doc) => doc.id).toSet();
 
-        return snapshot.docs
+        final threads = snapshot.docs
             .map((doc) {
               try {
                 final data = doc.data() as Map<String, dynamic>;
 
                 final userIds = List<String>.from(data['userIds'] ?? []);
                 final otherUserId = userIds.firstWhere(
-                  (id) => id != currentUserId,
+                  (id) => id != userId,
                   orElse: () => '',
                 );
 
@@ -681,7 +681,7 @@ class ChatService {
 
                 final unreadCount =
                     data['unreadCount'] as Map<String, dynamic>?;
-                final unread = (unreadCount?[currentUserId] ?? 0) > 0;
+                final unread = (unreadCount?[userId] ?? 0) > 0;
 
                 return MessageThreadInfo(
                   threadId: doc.id,
@@ -726,7 +726,10 @@ class ChatService {
                   thread.otherUserId.isNotEmpty &&
                   !blockedIds.contains(thread.otherUserId),
             )
-            .toList();
+            .toList()
+          ..sort((a, b) => b.timestamp.compareTo(a.timestamp));
+
+        return threads;
       } on FirebaseException catch (e) {
         AppLogger.error(
           'Firebase error mapping chat threads: ${e.code} - ${e.message}',

--- a/lib/features/onboarding/data/repositories/onboarding_repository.dart
+++ b/lib/features/onboarding/data/repositories/onboarding_repository.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter/foundation.dart';
 
 import '../../../../common/utils/app_logger.dart';
 import '../../bloc/onboarding_data.dart';
@@ -89,12 +90,18 @@ class OnboardingRepository {
         'dateOfBirth': d.dateOfBirth?.toIso8601String(),
         'age': d.age,
         'gender': d.gender,
+        'userGender': d.gender,
+        'showGender': d.interestedIn,
         'bio': d.bio,
         'interests': d.interests,
         'height': d.height,
         'lookingFor': d.lookingFor,
         'relationshipIntent': d.relationshipIntent,
         'interestedIn': d.interestedIn,
+        'editInfo': {
+          'userGender': d.gender,
+          'userName': d.fullName,
+        },
         'ageRange': {
           'min': d.ageRange[0].toString(),
           'max': d.ageRange[1].toString(),
@@ -295,4 +302,8 @@ class OnboardingRepository {
       'isProfileComplete': true,
     };
   }
+
+  @visibleForTesting
+  Map<String, dynamic> buildEssentialDataForTesting(OnboardingData data) =>
+      _buildEssentialData(data);
 }

--- a/lib/services/firestore_database.dart
+++ b/lib/services/firestore_database.dart
@@ -32,24 +32,21 @@ class FireStoreClass {
       final UploadTask uploadTask = storageReference.putFile(file);
 
       try {
-        await uploadTask;
-        final fileURL = await storageReference.getDownloadURL();
-        try {
-          log('Updating profile picture with URL: $fileURL');
-          await firebaseFireStoreInstance
-              .collection('users')
-              .doc(currentUserId)
-              .set(
-            {
-              'Pictures': [fileURL],
-            },
-            SetOptions(merge: true),
-          );
-        } on Object catch (e) {
-          log('Error updating Firestore with image URL: $e');
-        }
+        final snapshot = await uploadTask;
+        final fileURL = await snapshot.ref.getDownloadURL();
+        log('Updating profile picture with URL: $fileURL');
+        await firebaseFireStoreInstance
+            .collection('users')
+            .doc(currentUserId)
+            .set(
+          {
+            'Pictures': FieldValue.arrayUnion([fileURL]),
+          },
+          SetOptions(merge: true),
+        );
       } on Object catch (e) {
         log('Error in upload task: $e');
+        return null;
       }
       return uploadTask;
     } on Object catch (e) {
@@ -85,14 +82,18 @@ class FireStoreClass {
         final TaskSnapshot snapshot = await uploadTask;
         final String downloadUrl = await snapshot.ref.getDownloadURL();
 
-        // Update user document with verification status
-        await firebaseFireStoreInstance.collection('users').doc(userId).set(
+        // Keep verification metadata in a private subcollection, not on the
+        // public profile root document.
+        await firebaseFireStoreInstance
+            .collection('users')
+            .doc(userId)
+            .collection('verification')
+            .doc('current')
+            .set(
           {
-            'verification': {
-              'status': 'pending',
-              'imageUrl': downloadUrl,
-              'submittedAt': FieldValue.serverTimestamp(),
-            },
+            'status': 'pending',
+            'imageUrl': downloadUrl,
+            'submittedAt': FieldValue.serverTimestamp(),
           },
           SetOptions(merge: true),
         );
@@ -134,46 +135,25 @@ class FireStoreClass {
       final UploadTask uploadTask = storageReference.putFile(file);
 
       try {
-        await uploadTask;
-        final fileURL = await storageReference.getDownloadURL();
+        final snapshot = await uploadTask;
+        final fileURL = await snapshot.ref.getDownloadURL();
 
-        // Initialize Pictures array if it doesn't exist
-        final DocumentSnapshot userDoc = await firebaseFireStoreInstance
+        if (checktype == 'profile') {
+          log('Updating profile picture with URL: $fileURL');
+        }
+
+        await firebaseFireStoreInstance
             .collection('users')
             .doc(currentUser.id)
-            .get();
-
-        List<String> pictures = [];
-        if (userDoc.exists && userDoc.data() is Map<String, dynamic>) {
-          final Map<String, dynamic> userData =
-              userDoc.data() as Map<String, dynamic>;
-          if (userData.containsKey('Pictures') &&
-              userData['Pictures'] is List) {
-            pictures = List<String>.from(userData['Pictures']);
-          }
-        }
-
-        // Add new image URL
-        pictures.add(fileURL);
-
-        try {
-          if (checktype == 'profile') {
-            log('Updating profile picture with URL: $fileURL');
-            await firebaseFireStoreInstance
-                .collection('users')
-                .doc(currentUser.id)
-                .set({'Pictures': pictures}, SetOptions(merge: true));
-          } else {
-            await firebaseFireStoreInstance
-                .collection('users')
-                .doc(currentUser.id)
-                .update({'Pictures': pictures});
-          }
-        } on Object catch (e) {
-          log('Error updating Firestore with image URL: $e');
-        }
+            .set(
+          {
+            'Pictures': FieldValue.arrayUnion([fileURL]),
+          },
+          SetOptions(merge: true),
+        );
       } on Object catch (e) {
         log('Error in upload task: $e');
+        return null;
       }
       return uploadTask;
     } on Object catch (e) {

--- a/storage.rules
+++ b/storage.rules
@@ -63,6 +63,39 @@ service firebase.storage {
       allow read: if isSignedIn();
     }
 
+    // Profile verification images — owner only.
+    match /verification/{userId}/{allPaths=**} {
+      allow read: if isSignedIn() && request.auth.uid == userId;
+      allow write: if isSignedIn() &&
+                   request.auth.uid == userId &&
+                   isImageUpload() &&
+                   isReasonableImageSize();
+    }
+
+    // Chat media for legacy /chats threads.
+    match /chats/{chatId}/{allPaths=**} {
+      allow read: if isSignedIn()
+                  && firestore.exists(/databases/(default)/documents/chats/$(chatId))
+                  && request.auth.uid in firestore.get(/databases/(default)/documents/chats/$(chatId)).data.users;
+      allow write: if isSignedIn()
+                   && firestore.exists(/databases/(default)/documents/chats/$(chatId))
+                   && request.auth.uid in firestore.get(/databases/(default)/documents/chats/$(chatId)).data.users
+                   && isImageUpload()
+                   && isReasonableImageSize();
+    }
+
+    // Chat media for chatThreads collection.
+    match /chatThreads/{threadId}/{allPaths=**} {
+      allow read: if isSignedIn()
+                  && firestore.exists(/databases/(default)/documents/chatThreads/$(threadId))
+                  && request.auth.uid in firestore.get(/databases/(default)/documents/chatThreads/$(threadId)).data.userIds;
+      allow write: if isSignedIn()
+                   && firestore.exists(/databases/(default)/documents/chatThreads/$(threadId))
+                   && request.auth.uid in firestore.get(/databases/(default)/documents/chatThreads/$(threadId)).data.userIds
+                   && isImageUpload()
+                   && isReasonableImageSize();
+    }
+
     // Legacy group avatar paths (without owner prefix) remain read-only.
     match /group_avatars/{allPaths=**} {
       allow read: if isSignedIn();

--- a/test/auth/authstatus_bloc_test.dart
+++ b/test/auth/authstatus_bloc_test.dart
@@ -1,0 +1,52 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:naijasingles/common/data/repo/phone_auth_repo.dart';
+import 'package:naijasingles/features/auth/auth_status/bloc/authstatus_bloc.dart';
+
+class MockPhoneAuthRepository extends Mock implements PhoneAuthRepository {}
+
+class MockFirebaseUser extends Mock implements User {}
+
+void main() {
+  group('AuthstatusBloc', () {
+    late MockPhoneAuthRepository repo;
+    late MockFirebaseUser user;
+
+    setUp(() {
+      repo = MockPhoneAuthRepository();
+      user = MockFirebaseUser();
+    });
+
+    blocTest<AuthstatusBloc, AuthstatusState>(
+      'emits AuthenticatedState when Firebase has a persisted user session',
+      build: () {
+        when(() => repo.isSignedIn()).thenAnswer((_) async => true);
+        when(() => repo.getCurrentUser()).thenAnswer((_) async => user);
+        when(() => user.phoneNumber).thenReturn('+15555550100');
+        when(() => user.uid).thenReturn('user-1');
+        when(() => user.getIdToken(true)).thenAnswer((_) async => 'token');
+        return AuthstatusBloc(phoneAuthRepository: repo);
+      },
+      act: (bloc) => bloc.add(AuthRequestEvent()),
+      expect: () => [
+        AuthLoadingState(),
+        AuthenticatedState(user: user),
+      ],
+    );
+
+    blocTest<AuthstatusBloc, AuthstatusState>(
+      'emits UnauthenticatedState when Firebase has no persisted user session',
+      build: () {
+        when(() => repo.isSignedIn()).thenAnswer((_) async => false);
+        return AuthstatusBloc(phoneAuthRepository: repo);
+      },
+      act: (bloc) => bloc.add(AuthRequestEvent()),
+      expect: () => [
+        AuthLoadingState(),
+        UnauthenticatedState(),
+      ],
+    );
+  });
+}

--- a/test/features/onboarding/onboarding_essential_data_test.dart
+++ b/test/features/onboarding/onboarding_essential_data_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naijasingles/features/onboarding/bloc/onboarding_data.dart';
+import 'package:naijasingles/features/onboarding/data/repositories/onboarding_repository.dart';
+
+void main() {
+  group('OnboardingRepository essential data', () {
+    final repository = OnboardingRepository();
+
+    test('persists gender fields required for discovery queries', () {
+      final data = OnboardingData(
+        fullName: 'Amina',
+        dateOfBirth: DateTime(1995, 3, 15),
+        gender: 'Female',
+        interestedIn: 'Male',
+        bio: 'Building meaningful connections in the diaspora.',
+        interests: const ['music', 'travel', 'food'],
+        nationality: 'Nigeria',
+        locationName: 'London',
+        latitude: 51.5074,
+        longitude: -0.1278,
+        maxDistance: 50,
+      );
+
+      final payload = repository.buildEssentialDataForTesting(data);
+
+      expect(payload['userGender'], 'Female');
+      expect(payload['gender'], 'Female');
+      expect(payload['showGender'], 'Male');
+      expect(payload['editInfo'], isA<Map>());
+      expect(payload['editInfo']['userGender'], 'Female');
+      expect(payload['onboardingCompleted'], isTrue);
+    });
+  });
+}

--- a/test/messages/chat_service_test.dart
+++ b/test/messages/chat_service_test.dart
@@ -6,7 +6,8 @@ import 'package:naijasingles/features/messages/services/chat_service.dart';
 
 void main() {
   group('ChatService', () {
-    test('streams current user threads ordered by most recent update', () async {
+    test('streams current user threads ordered by most recent update',
+        () async {
       final firestore = FakeFirebaseFirestore();
       final auth = MockFirebaseAuth(
         signedIn: true,

--- a/test/messages/chat_service_test.dart
+++ b/test/messages/chat_service_test.dart
@@ -1,0 +1,53 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naijasingles/features/messages/services/chat_service.dart';
+
+void main() {
+  group('ChatService', () {
+    test('streams current user threads ordered by most recent update', () async {
+      final firestore = FakeFirebaseFirestore();
+      final auth = MockFirebaseAuth(
+        signedIn: true,
+        mockUser: MockUser(uid: 'current-user'),
+      );
+      final service = ChatService(firestore: firestore, auth: auth);
+
+      await firestore.collection('chatThreads').doc('older-thread').set({
+        'userIds': ['current-user', 'older-match'],
+        'userNames': {
+          'current-user': 'Current User',
+          'older-match': 'Older Match',
+        },
+        'lastMessageText': 'Older message',
+        'lastUpdated': Timestamp.fromDate(DateTime(2026, 5, 1, 10)),
+        'unreadCount': {'current-user': 0},
+      });
+      await firestore.collection('chatThreads').doc('newer-thread').set({
+        'userIds': ['current-user', 'newer-match'],
+        'userNames': {
+          'current-user': 'Current User',
+          'newer-match': 'Newer Match',
+        },
+        'lastMessageText': 'Newer message',
+        'lastUpdated': Timestamp.fromDate(DateTime(2026, 5, 2, 10)),
+        'unreadCount': {'current-user': 1},
+      });
+      await firestore.collection('chatThreads').doc('unrelated-thread').set({
+        'userIds': ['someone-else', 'another-user'],
+        'lastMessageText': 'Should not be visible',
+        'lastUpdated': Timestamp.fromDate(DateTime(2026, 5, 3, 10)),
+      });
+
+      final threads = await service.getChatThreadsStream().first;
+
+      expect(threads.map((thread) => thread.threadId), [
+        'newer-thread',
+        'older-thread',
+      ]);
+      expect(threads.first.otherUserName, 'Newer Match');
+      expect(threads.first.unread, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Single replacement PR for draft fixes #1, #3, #9, #10, and corrected #14. Supersedes unsafe/incomplete drafts #2, #4–#8, #11–#13.

- **Auth (#1):** Restore persisted sessions via `PhoneAuthRepository.getCurrentUser()` with regression tests.
- **Messages (#3):** Drop composite `orderBy` from `getChatThreadsStream()`; sort client-side to avoid index dependency.
- **Storage (#9):** Add owner-scoped `verification/`, chat-participant media paths, and deny-all fallback while preserving existing profile/event/group paths.
- **Firestore (corrected #14):** Participant-scoped `/calls` rules (`create` validates `request.resource.data`); owner-only `users/{uid}/verification` subcollection; retain premium field deny-list (not `isPremium == false` gate); default-deny catch-all preserved.
- **Onboarding (#10):** Legacy fallback payload now includes `userGender` / `editInfo.userGender`; regression test for discovery-critical fields.
- **Verification uploads:** Metadata written to `users/{uid}/verification/current` subcollection instead of public root doc.

## Test plan

- [x] `flutter test test/auth/authstatus_bloc_test.dart test/messages/chat_service_test.dart test/features/onboarding/onboarding_essential_data_test.dart`
- [x] `cd functions && npm run test:rules` (Firestore + Storage emulator rules suite)
- [x] `flutter analyze` on touched Dart files
- [ ] Manual: cold-start app with persisted Firebase session → lands authenticated
- [ ] Manual: Messages tab loads threads without composite-index error
- [ ] Manual: verification image upload succeeds; non-owner cannot read `verification/{uid}/`

## Supersedes

Closes #1, #3, #9, #10, #14 once merged. After green CI, close #2, #4, #5, #6, #7, #8, #11, #12, #13 as superseded by this PR.


Made with [Cursor](https://cursor.com)