### PR TITLE
Add /fix command and screenshot-driven AI workflow

### DIFF
--- a/.cursor/commands/fix.md
+++ b/.cursor/commands/fix.md
@@ -1,0 +1,68 @@
+# fix
+
+When the user says `/fix` or pastes an app screenshot with a bug/UI issue to fix, run the AfroPeep screenshot-fix workflow end-to-end. Follow `.cursor/rules/screenshot-fix-workflow.mdc` exactly.
+
+## Trigger
+
+- `/fix` with an attached screenshot, screen recording, or short description of what is broken
+- Optional: user adds context after `/fix` (e.g. `/fix back button missing on settings`)
+
+## Workflow (execute in order)
+
+### 1. Triage (no code yet)
+
+- Describe what is visible in the screenshot (screen name, widgets, text, layout).
+- State what is wrong vs what should happen.
+- Classify branch type: `fix/` (bug/regression), `feature/` (new capability), `refactor/`, or `chore/`.
+- Ask at most 1–2 clarifying questions only if blocked.
+
+### 2. Git setup
+
+From repo root (`pubspec.yaml`):
+
+```bash
+git fetch origin
+git checkout develop
+git pull origin develop
+git checkout -b <type>/<short-kebab-description>
+```
+
+- Never commit to `develop` or `main` directly.
+- Do not commit or push unless the user explicitly asks.
+- Production hotfix: branch from `main` instead, PR to `main`, then back-merge to `develop`.
+
+### 3. Investigate
+
+1. Read `PROJECT_CONTEXT.md` if the feature area is unfamiliar.
+2. Locate the screen in `lib/features/` (visible text, route, AppBar title).
+3. Trace: Screen → Widget → BLoC → Repository → Service/Firebase.
+4. Reuse existing patterns; grep for similar fixes.
+5. Use Dart MCP for analysis/tests when available.
+
+### 4. Implement
+
+- Minimal diff — fix only the reported issue.
+- BLoC for shared/async state; repository pattern for data; no Firestore in widgets.
+- Material 3, brand colors (green accents, `#FFF6E5` background), Montserrat.
+- `const` where possible; null safety; no hardcoded secrets.
+
+### 5. Verify
+
+```bash
+flutter analyze
+flutter test
+```
+
+Add focused widget/unit tests when the fix is non-trivial. Give numbered manual retest steps for the same screen.
+
+### 6. Report
+
+Reply with:
+
+1. **Root cause** — plain language
+2. **Changes** — files + key edits (code citations)
+3. **How to verify** — retest steps
+4. **Branch name**
+5. **Next steps** — offer `/pr` when ready to ship (PR targets `develop`)
+
+This command will be available in chat with `/fix`

--- a/.cursor/rules/screenshot-fix-workflow.mdc
+++ b/.cursor/rules/screenshot-fix-workflow.mdc
@@ -1,0 +1,117 @@
+---
+description: "Workflow when user pastes an app screenshot or reports a UI bug during testing. Triage, branch from develop, investigate, fix, verify."
+alwaysApply: true
+---
+
+# Screenshot & In-App Issue Workflow
+
+When the user pastes a **screenshot**, screen recording, or describes something they see **while testing the app**, follow this workflow before writing code.
+
+## 1. Triage the Screenshot (do not code yet)
+
+1. **Describe what you see** — screen, visible widgets, text, errors, layout issues.
+2. **State the problem** — what is wrong vs expected (spacing, crash, wrong data, missing element, etc.).
+3. **Classify the work:**
+   - `fix/` — bug, crash, visual regression, broken flow
+   - `feature/` — new capability or meaningful UX addition
+   - `refactor/` — structural change, no user-visible change
+   - `chore/` — tooling, deps, config only
+4. **Ask at most 1–2 questions** only if blocked (e.g. expected behavior is ambiguous).
+
+## 2. Git Setup (always before changes)
+
+Work from the **repository root** (directory with `pubspec.yaml`).
+
+```bash
+git fetch origin
+git checkout develop
+git pull origin develop
+git checkout -b fix/short-kebab-description   # or feature/, refactor/, chore/
+```
+
+Rules:
+- **Never** commit directly to `develop` or `main`.
+- Branch names: lowercase kebab-case, prefixed by type (`fix/login-button-overflow`).
+- **Do not commit or push** unless the user explicitly asks.
+- Hotfixes to production: branch from `main` as `fix/critical-description`, then back-merge to `develop`.
+
+## 3. Investigate in the Codebase
+
+Trace the issue top-down before editing:
+
+1. Read `PROJECT_CONTEXT.md` if the feature area is unfamiliar.
+2. **Locate the screen** — search `lib/features/` by visible text, route name, or AppBar title.
+3. **Trace the stack:**
+   ```
+   Screen (presentation/screens/)
+     → Widgets (presentation/widgets/)
+     → BLoC (presentation/bloc/)
+     → Repository (data/repositories/)
+     → Service / Firebase (data/services/)
+   ```
+4. **Find existing patterns** — grep for similar widgets, BLoCs, or fixes; reuse, don't reinvent.
+5. **Check data layer** if the issue is wrong/missing content (Firestore rules, model parsing, stream listeners).
+
+Use the Dart MCP server for analysis and tests when available.
+
+## 4. Implement the Fix
+
+### Scope
+- **Minimal diff** — fix only what the screenshot/issue shows; no drive-by refactors.
+- Match surrounding code style, naming, and architecture.
+
+### Architecture (AfroPeep)
+- Feature modules under `lib/features/{feature}/` with `data/`, `domain/`, `presentation/`.
+- **BLoC** for shared/async state; local `StatefulWidget` state only for trivial UI-only toggles.
+- **Repository pattern** for Firebase and API access — no direct Firestore calls from widgets.
+- **Null safety** (Dart 3.5+), `const` constructors where possible.
+
+### UI & Design
+- Material 3 components.
+- Brand: green accents, background `#FFF6E5`, Montserrat typography.
+- Responsive layouts; test overflow on small screens.
+- Accessibility: semantics labels on interactive elements.
+
+### Security
+- Never hardcode secrets; use `.env` / env config.
+- Validate user input; respect Firestore security rules.
+
+## 5. Verify Before Handing Off
+
+Run from repo root:
+
+```bash
+flutter analyze
+flutter test                                    # all tests
+flutter test test/path/to_relevant_test.dart    # focused, when applicable
+```
+
+Provide **manual retest steps** the user can follow on the same screen shown in the screenshot.
+
+For UI changes, note iOS vs Android if platform-specific (safe area, keyboard, fonts).
+
+## 6. Report Back
+
+Structure the response as:
+
+1. **What was wrong** — root cause in plain language.
+2. **What changed** — files and behavior (use code citations for key edits).
+3. **How to verify** — numbered steps matching the original screen.
+4. **Branch name** — so the user knows where work lives.
+5. **Next steps** — offer commit/PR only if the user wants to ship; use `/pr` or `gh pr create` targeting `develop`.
+
+## Quick Reference
+
+| Issue type | Branch prefix | PR target |
+|------------|---------------|-----------|
+| Bug / visual fix | `fix/` | `develop` |
+| New feature | `feature/` | `develop` |
+| Production hotfix | `fix/` (from `main`) | `main`, then merge to `develop` |
+| Refactor | `refactor/` | `develop` |
+
+| Layer | Location |
+|-------|----------|
+| Screens | `lib/features/*/presentation/screens/` |
+| BLoC | `lib/features/*/presentation/bloc/` |
+| Repos | `lib/features/*/data/repositories/` |
+| Theme | `lib/core/` |


### PR DESCRIPTION
## Summary
- Add `.cursor/rules/screenshot-fix-workflow.mdc` — always-on rule for triaging in-app screenshots, branching from `develop`, investigating the Flutter stack, and verifying fixes
- Add `.cursor/commands/fix.md` — `/fix` slash command that runs the same workflow end-to-end

## Why
Standardizes how AI agents handle bugs and UI issues found during manual testing: triage → branch → investigate → minimal fix → `flutter analyze` / tests → clear retest steps.

## Test plan
- [x] Rule and command files are valid Markdown
- [ ] In Cursor chat, paste a screenshot and run `/fix` — agent should triage before coding and propose a `fix/` branch from `develop`
- [ ] After merge, confirm `/fix` appears in the command palette

## Notes
Cherry-picked onto `main` as an isolated PR (develop also has this commit for integration-branch continuity).


Made with [Cursor](https://cursor.com)