### PR TITLE
fix(auth): improve phone number label contrast on green background

### DIFF
--- a/lib/features/auth/phone/ui/screens/update_phonenumber.dart
+++ b/lib/features/auth/phone/ui/screens/update_phonenumber.dart
@@ -45,6 +45,7 @@ class UpdateNumber extends StatelessWidget {
                   style: const TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.bold,
+                    color: AppColors.textOnPrimary,
                   ),
                 ),
               ),
@@ -87,10 +88,10 @@ class UpdateNumber extends StatelessWidget {
                   currentUser.phoneNumber!.isNotEmpty
                       ? 'Verified phone number'.tr().toString()
                       : ' Add Verified phone number'.tr().toString(),
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 13,
                     fontWeight: FontWeight.w400,
-                    color: AppColors.secondaryColor,
+                    color: AppColors.textOnPrimary.withValues(alpha: 0.85),
                   ),
                 ),
               ),


### PR DESCRIPTION
## Summary
- Fix low-contrast "Phone number" and "Verified phone number" labels on the update phone number screen
- Use `AppColors.textOnPrimary` (white) for the heading and a slightly dimmed variant for the subtitle on the green background

## Test plan
- [ ] Open Settings → Phone number (update phone screen)
- [ ] Confirm "Phone number" and "Verified phone number" are clearly readable on green background
- [ ] Confirm white card, checkmark, and "Update my phone number" button are unchanged
- [x] `flutter analyze` passes
- [x] `flutter test` passes


Made with [Cursor](https://cursor.com)