### PR TITLE
fix(messages): matched profile view and thread profile loading

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,11 +1,18 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    function hasLegacyMatchWith(userId) {
+      return exists(/databases/$(database)/documents/users/$(request.auth.uid)/Matches/$(userId)) ||
+             exists(/databases/$(database)/documents/users/$(userId)/Matches/$(request.auth.uid));
+    }
+
     function canReadUserProfile(userId) {
       return request.auth != null &&
              (
                // Owner always reads own profile document.
                request.auth.uid == userId ||
+               // Matched users can read each other's profiles for chat context.
+               hasLegacyMatchWith(userId) ||
                (
                 // Non-owners can read active/public profiles.
                 // Paused and incognito profiles are blocked here so that

--- a/functions/test/firestore.rules.test.ts
+++ b/functions/test/firestore.rules.test.ts
@@ -180,6 +180,36 @@ describe('firestore.rules', () => {
     await assertFails(db.collection('calls').doc('call-3').get());
   });
 
+  test('matched user can read a private profile when legacy match exists', async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const adminDb = context.firestore();
+      await adminDb.collection('users').doc('matcher-a').set({
+        name: 'Matcher A',
+        isProfilePrivate: false,
+        isDeleted: false,
+        accountStatus: 'active',
+      });
+      await adminDb.collection('users').doc('matcher-b').set({
+        name: 'Matcher B',
+        isProfilePrivate: true,
+        isDeleted: false,
+        accountStatus: 'active',
+      });
+      await adminDb
+        .collection('users')
+        .doc('matcher-a')
+        .collection('Matches')
+        .doc('matcher-b')
+        .set({
+          Matches: 'matcher-b',
+          userName: 'Matcher B',
+        });
+    });
+
+    const db = testEnv.authenticatedContext('matcher-a').firestore();
+    await assertSucceeds(db.collection('users').doc('matcher-b').get());
+  });
+
   test('unknown top-level collection is denied', async () => {
     const db = testEnv.authenticatedContext('any-user').firestore();
     await assertFails(

--- a/lib/features/dating/screens/user_detail_screen.dart
+++ b/lib/features/dating/screens/user_detail_screen.dart
@@ -20,9 +20,13 @@ class UserDetailScreen extends StatefulWidget {
     required this.user,
     super.key,
     this.selectedMode,
+    this.showLikeActions = true,
   });
   final UserModel user;
   final String? selectedMode;
+
+  /// Hide like/pass actions when viewing someone you are already messaging.
+  final bool showLikeActions;
 
   @override
   State<UserDetailScreen> createState() => _UserDetailScreenState();
@@ -34,7 +38,7 @@ class _UserDetailScreenState extends State<UserDetailScreen> {
   bool _isLiking = false;
   bool _checkingLikeStatus = true;
   bool _alreadyLiked = false;
-  final MatchService _matchService = MatchService();
+  MatchService? _matchService;
 
   // MVP theme colors
   static const Color afropeepGreen = Color(0xFF008037); // MVP green
@@ -45,7 +49,11 @@ class _UserDetailScreenState extends State<UserDetailScreen> {
   @override
   void initState() {
     super.initState();
-    unawaited(_loadExistingLikeState());
+    if (widget.showLikeActions) {
+      unawaited(_loadExistingLikeState());
+    } else {
+      _checkingLikeStatus = false;
+    }
   }
 
   Future<void> _loadExistingLikeState() async {
@@ -54,7 +62,7 @@ class _UserDetailScreenState extends State<UserDetailScreen> {
       if (mounted) setState(() => _checkingLikeStatus = false);
       return;
     }
-    final liked = await _matchService.hasUserLiked(id);
+    final liked = await (_matchService ??= MatchService()).hasUserLiked(id);
     if (!mounted) return;
     setState(() {
       _alreadyLiked = liked;
@@ -195,7 +203,7 @@ class _UserDetailScreenState extends State<UserDetailScreen> {
               ],
             ),
           ),
-          _buildBottomActionBar(),
+          if (widget.showLikeActions) _buildBottomActionBar(),
         ],
       ),
     );
@@ -230,7 +238,8 @@ class _UserDetailScreenState extends State<UserDetailScreen> {
                     : () async {
                         setState(() => _isLiking = true);
                         try {
-                          final outcome = await _matchService
+                          final outcome = await (_matchService ??=
+                                  MatchService())
                               .handleLikeWithOutcome(targetUserId);
                           if (!mounted) return;
                           setState(() => _isLiking = false);
@@ -907,8 +916,8 @@ class _UserDetailScreenState extends State<UserDetailScreen> {
       interests.add('💼 ${widget.user.occupation}');
     }
 
-    // Add default interests if none found
-    if (interests.isEmpty) {
+    // Placeholder interests only for discovery previews with sparse data.
+    if (interests.isEmpty && widget.showLikeActions) {
       interests.addAll(['Dating', 'Music', 'Travel']);
     }
 

--- a/lib/features/messages/chat_thread_screen.dart
+++ b/lib/features/messages/chat_thread_screen.dart
@@ -10,7 +10,6 @@ import 'package:image_picker/image_picker.dart';
 
 import '../../common/constants/app_colors.dart';
 import '../../common/widgets/state_views/state_views.dart';
-import '../../models/user_model.dart';
 import '../../services/media_sharing_service.dart';
 import '../../services/settings_service.dart';
 import '../chat_shared/models/chat_message_view_model.dart';
@@ -19,6 +18,7 @@ import '../chat_shared/ui/widgets/chat_composer.dart';
 import '../dating/screens/user_detail_screen.dart';
 import 'message_model.dart';
 import 'services/chat_service.dart';
+import 'services/matched_user_profile_loader.dart';
 import 'widgets/pre_meet_safety_sheet.dart';
 
 class ChatThreadScreen extends StatefulWidget {
@@ -606,13 +606,13 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
         ),
       );
 
-      // Fetch user data from Firestore
-      final userDoc = await FirebaseFirestore.instance
-          .collection('users')
-          .doc(widget.otherUserId)
-          .get();
+      final userModel = await MatchedUserProfileLoader.load(
+        firestore: FirebaseFirestore.instance,
+        userId: widget.otherUserId!,
+        fallbackName: widget.userName,
+        fallbackAvatarUrl: widget.avatarUrl,
+      );
 
-      // Close loading dialog
       if (mounted) {
         Navigator.pop(context);
       }
@@ -621,45 +621,15 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
         return;
       }
 
-      if (userDoc.exists) {
-        final userData = userDoc.data() as Map<String, dynamic>;
-
-        // Convert Firestore data to UserModel
-        final userModel = UserModel(
-          id: widget.otherUserId,
-          name: userData['name'] ?? widget.userName,
-          age: userData['age'] ?? 0,
-          imageUrl: List<String>.from(
-            userData['photos'] ?? userData['imageUrl'] ?? [],
+      unawaited(
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => UserDetailScreen(user: userModel),
           ),
-          address: userData['locationName'] ?? userData['address'],
-          distanceBW: userData['distanceBW'],
-          editInfo: userData['editInfo'] ?? {},
-        );
-
-        // Navigate to profile screen
-        unawaited(
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (context) => UserDetailScreen(user: userModel),
-            ),
-          ),
-        );
-      } else {
-        // Show error if user not found
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              'User profile not found',
-              style: GoogleFonts.montserrat(color: Colors.white),
-            ),
-            backgroundColor: Colors.red,
-          ),
-        );
-      }
+        ),
+      );
     } on Object catch (e) {
-      // Close loading dialog if still open
       if (mounted) {
         Navigator.pop(context);
       }
@@ -668,13 +638,19 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
       if (!mounted) {
         return;
       }
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            'Failed to load profile',
-            style: GoogleFonts.montserrat(color: Colors.white),
+
+      final fallbackUser = MatchedUserProfileLoader.buildFallback(
+        userId: widget.otherUserId!,
+        fallbackName: widget.userName,
+        fallbackAvatarUrl: widget.avatarUrl,
+      );
+
+      unawaited(
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => UserDetailScreen(user: fallbackUser),
           ),
-          backgroundColor: Colors.red,
         ),
       );
     }

--- a/lib/features/messages/chat_thread_screen.dart
+++ b/lib/features/messages/chat_thread_screen.dart
@@ -625,7 +625,10 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
         Navigator.push(
           context,
           MaterialPageRoute(
-            builder: (context) => UserDetailScreen(user: userModel),
+            builder: (context) => UserDetailScreen(
+              user: userModel,
+              showLikeActions: false,
+            ),
           ),
         ),
       );
@@ -649,7 +652,10 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
         Navigator.push(
           context,
           MaterialPageRoute(
-            builder: (context) => UserDetailScreen(user: fallbackUser),
+            builder: (context) => UserDetailScreen(
+              user: fallbackUser,
+              showLikeActions: false,
+            ),
           ),
         ),
       );

--- a/lib/features/messages/messages_screen.dart
+++ b/lib/features/messages/messages_screen.dart
@@ -8,12 +8,12 @@ import 'package:google_fonts/google_fonts.dart';
 
 import '../../common/constants/app_colors.dart';
 import '../../common/widgets/state_views/state_views.dart';
-import '../../models/user_model.dart'; // Import UserModel
 import '../dating/screens/user_detail_screen.dart'; // Import for profile viewing
 import '../explore/explore_screen.dart'; // Import ExploreScreen directly
 import 'chat_thread_screen.dart';
 import 'message_model.dart';
 import 'services/chat_service.dart';
+import 'services/matched_user_profile_loader.dart';
 
 class MessagesScreen extends StatefulWidget {
   const MessagesScreen({super.key});
@@ -154,7 +154,7 @@ class _MessagesScreenState extends State<MessagesScreen> {
                     Stack(
                       children: [
                         GestureDetector(
-                          onTap: () => _viewUserProfile(thread.otherUserId),
+                          onTap: () => _viewUserProfile(thread),
                           child: Container(
                             width: 60,
                             height: 60,
@@ -195,7 +195,9 @@ class _MessagesScreenState extends State<MessagesScreen> {
                                 color: AppColors.primaryGreen,
                                 shape: BoxShape.circle,
                                 border: Border.all(
-                                    color: AppColors.cardColor, width: 2),
+                                  color: AppColors.cardColor,
+                                  width: 2,
+                                ),
                               ),
                             ),
                           ),
@@ -211,8 +213,7 @@ class _MessagesScreenState extends State<MessagesScreen> {
                             children: [
                               Expanded(
                                 child: GestureDetector(
-                                  onTap: () =>
-                                      _viewUserProfile(thread.otherUserId),
+                                  onTap: () => _viewUserProfile(thread),
                                   child: Text(
                                     thread.otherUserName,
                                     style: GoogleFonts.montserrat(
@@ -586,7 +587,7 @@ class _MessagesScreenState extends State<MessagesScreen> {
   }
 
   // Method to view user profile from messages
-  Future<void> _viewUserProfile(String userId) async {
+  Future<void> _viewUserProfile(MessageThreadInfo thread) async {
     if (!mounted) return;
 
     try {
@@ -648,75 +649,46 @@ class _MessagesScreenState extends State<MessagesScreen> {
         ),
       );
 
-      // Fetch user data from Firestore
-      final userDoc = await _firestore.collection('users').doc(userId).get();
+      final userModel = await MatchedUserProfileLoader.load(
+        firestore: _firestore,
+        userId: thread.otherUserId,
+        fallbackName: thread.otherUserName,
+        fallbackAvatarUrl: thread.avatarUrl,
+      );
 
-      // Close loading dialog
       if (mounted && Navigator.canPop(context)) {
         Navigator.pop(context);
       }
 
       if (!mounted) return;
 
-      if (userDoc.exists) {
-        final userData = userDoc.data() as Map<String, dynamic>;
-
-        // Convert Firestore data to UserModel
-        final userModel = UserModel(
-          id: userId,
-          name: userData['name'] ?? 'Unknown User',
-          age: userData['age'] ?? 0,
-          imageUrl: List<String>.from(
-            userData['photos'] ?? userData['imageUrl'] ?? [],
+      unawaited(
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => UserDetailScreen(user: userModel),
           ),
-          address: userData['locationName'] ?? userData['address'],
-          distanceBW: userData['distanceBW'],
-          editInfo: userData['editInfo'] ?? {},
-        );
-
-        // Navigate to profile screen
-        unawaited(
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (context) => UserDetailScreen(user: userModel),
-            ),
-          ),
-        );
-      } else {
-        // Show error if user not found
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              'User profile not found',
-              style: GoogleFonts.montserrat(color: Colors.white),
-            ),
-            backgroundColor: Colors.red,
-            behavior: SnackBarBehavior.floating,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
-            ),
-          ),
-        );
-      }
+        ),
+      );
     } on Object catch (e) {
-      // Close loading dialog if still open
       if (mounted && Navigator.canPop(context)) {
         Navigator.pop(context);
       }
 
       log('Error loading user profile: $e');
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            'Failed to load profile',
-            style: GoogleFonts.montserrat(color: Colors.white),
-          ),
-          backgroundColor: Colors.red,
-          behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(8),
+
+      final fallbackUser = MatchedUserProfileLoader.buildFallback(
+        userId: thread.otherUserId,
+        fallbackName: thread.otherUserName,
+        fallbackAvatarUrl: thread.avatarUrl,
+      );
+
+      unawaited(
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => UserDetailScreen(user: fallbackUser),
           ),
         ),
       );

--- a/lib/features/messages/messages_screen.dart
+++ b/lib/features/messages/messages_screen.dart
@@ -154,6 +154,7 @@ class _MessagesScreenState extends State<MessagesScreen> {
                     Stack(
                       children: [
                         GestureDetector(
+                          behavior: HitTestBehavior.opaque,
                           onTap: () => _viewUserProfile(thread),
                           child: Container(
                             width: 60,
@@ -212,19 +213,16 @@ class _MessagesScreenState extends State<MessagesScreen> {
                           Row(
                             children: [
                               Expanded(
-                                child: GestureDetector(
-                                  onTap: () => _viewUserProfile(thread),
-                                  child: Text(
-                                    thread.otherUserName,
-                                    style: GoogleFonts.montserrat(
-                                      fontSize: 17,
-                                      fontWeight: thread.unread
-                                          ? FontWeight.bold
-                                          : FontWeight.w600,
-                                      color: AppColors.textPrimary,
-                                    ),
-                                    overflow: TextOverflow.ellipsis,
+                                child: Text(
+                                  thread.otherUserName,
+                                  style: GoogleFonts.montserrat(
+                                    fontSize: 17,
+                                    fontWeight: thread.unread
+                                        ? FontWeight.bold
+                                        : FontWeight.w600,
+                                    color: AppColors.textPrimary,
                                   ),
+                                  overflow: TextOverflow.ellipsis,
                                 ),
                               ),
                               Text(
@@ -666,7 +664,10 @@ class _MessagesScreenState extends State<MessagesScreen> {
         Navigator.push(
           context,
           MaterialPageRoute(
-            builder: (context) => UserDetailScreen(user: userModel),
+            builder: (context) => UserDetailScreen(
+              user: userModel,
+              showLikeActions: false,
+            ),
           ),
         ),
       );
@@ -688,7 +689,10 @@ class _MessagesScreenState extends State<MessagesScreen> {
         Navigator.push(
           context,
           MaterialPageRoute(
-            builder: (context) => UserDetailScreen(user: fallbackUser),
+            builder: (context) => UserDetailScreen(
+              user: fallbackUser,
+              showLikeActions: false,
+            ),
           ),
         ),
       );

--- a/lib/features/messages/services/matched_user_profile_loader.dart
+++ b/lib/features/messages/services/matched_user_profile_loader.dart
@@ -1,0 +1,59 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../../models/user_model.dart';
+
+/// Loads a matched user's profile for Messages, with thread-cache fallback.
+///
+/// Firestore may deny reads for private/paused profiles even between matches.
+/// When that happens, we still open a limited profile using chat thread data.
+class MatchedUserProfileLoader {
+  static Future<UserModel> load({
+    required FirebaseFirestore firestore,
+    required String userId,
+    required String fallbackName,
+    String? fallbackAvatarUrl,
+  }) async {
+    try {
+      final doc = await firestore.collection('users').doc(userId).get();
+      if (doc.exists) {
+        return UserModel.fromDocument(doc);
+      }
+    } on FirebaseException catch (e) {
+      if (e.code != 'permission-denied') {
+        rethrow;
+      }
+    }
+
+    return buildFallback(
+      userId: userId,
+      fallbackName: fallbackName,
+      fallbackAvatarUrl: fallbackAvatarUrl,
+    );
+  }
+
+  static UserModel buildFallback({
+    required String userId,
+    required String fallbackName,
+    String? fallbackAvatarUrl,
+  }) =>
+      _fallbackUser(
+        userId: userId,
+        fallbackName: fallbackName,
+        fallbackAvatarUrl: fallbackAvatarUrl,
+      );
+
+  static UserModel _fallbackUser({
+    required String userId,
+    required String fallbackName,
+    String? fallbackAvatarUrl,
+  }) =>
+      UserModel(
+        id: userId,
+        name: fallbackName,
+        age: 18,
+        imageUrl: fallbackAvatarUrl != null && fallbackAvatarUrl.isNotEmpty
+            ? [fallbackAvatarUrl]
+            : [],
+        editInfo: const {},
+      );
+}

--- a/test/dating/user_detail_screen_test.dart
+++ b/test/dating/user_detail_screen_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naijasingles/features/dating/screens/user_detail_screen.dart';
+import 'package:naijasingles/models/user_model.dart';
+
+void main() {
+  testWidgets('matched conversation profile hides like actions',
+      (tester) async {
+    final user = UserModel(
+      id: 'matched-user',
+      name: 'Phone User',
+      age: 18,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: UserDetailScreen(
+          user: user,
+          showLikeActions: false,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Like'), findsNothing);
+    expect(find.text('Liked'), findsNothing);
+    expect(find.text('Back'), findsNothing);
+    expect(find.text('Dating'), findsNothing);
+    expect(find.text('Music'), findsNothing);
+    expect(find.text('Travel'), findsNothing);
+    expect(find.text('Phone User, 18'), findsOneWidget);
+  });
+}

--- a/test/messages/matched_user_profile_loader_test.dart
+++ b/test/messages/matched_user_profile_loader_test.dart
@@ -1,0 +1,43 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naijasingles/features/messages/services/matched_user_profile_loader.dart';
+
+void main() {
+  group('MatchedUserProfileLoader', () {
+    test('returns parsed profile when user document exists', () async {
+      final firestore = FakeFirebaseFirestore();
+      await firestore.collection('users').doc('user-b').set({
+        'name': 'Ada',
+        'age': 27,
+        'photos': ['https://example.com/photo.jpg'],
+      });
+
+      final profile = await MatchedUserProfileLoader.load(
+        firestore: firestore,
+        userId: 'user-b',
+        fallbackName: 'Fallback',
+        fallbackAvatarUrl: 'https://example.com/fallback.jpg',
+      );
+
+      expect(profile.id, 'user-b');
+      expect(profile.name, 'Ada');
+      expect(profile.age, 27);
+      expect(profile.imageUrl, ['https://example.com/photo.jpg']);
+    });
+
+    test('falls back to thread cache when user document is missing', () async {
+      final firestore = FakeFirebaseFirestore();
+
+      final profile = await MatchedUserProfileLoader.load(
+        firestore: firestore,
+        userId: 'missing-user',
+        fallbackName: 'Phone User',
+        fallbackAvatarUrl: 'https://example.com/avatar.jpg',
+      );
+
+      expect(profile.id, 'missing-user');
+      expect(profile.name, 'Phone User');
+      expect(profile.imageUrl, ['https://example.com/avatar.jpg']);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Load matched user profiles from Messages with Firestore + thread-cache fallback (`MatchedUserProfileLoader`)
- Allow matched users to read each other's profiles via legacy `Matches` subcollection in Firestore rules
- Hide Like/Back actions when viewing a profile from an existing conversation (`showLikeActions: false`)
- Remove placeholder interests for sparse fallback profiles
- Open chat from thread row/title; profile opens from avatar only

## Supersedes
- Closes/supersedes #192 (same loader + rules work, plus matched-view UX fixes)

## Test plan
- [x] `flutter test test/messages/matched_user_profile_loader_test.dart`
- [x] `flutter test test/dating/user_detail_screen_test.dart`
- [x] `npm run test:rules`
- [ ] Messages → tap thread title/preview → opens chat
- [ ] Messages → tap avatar → opens profile without Like button
- [ ] Chat thread → tap profile header → profile without Like button


Made with [Cursor](https://cursor.com)