### PR TITLE
fix: stabilize chat, discovery filters, and paywall providers

### DIFF
--- a/functions/src/scripts/seedTestChatThread.ts
+++ b/functions/src/scripts/seedTestChatThread.ts
@@ -1,0 +1,156 @@
+/**
+ * Seed a chatThreads (+ optional matches) doc for manual Messages-tab QA.
+ *
+ * Usage:
+ *   cd functions
+ *   npx ts-node src/scripts/seedTestChatThread.ts \
+ *     --project naijasingles-74a75 \
+ *     --email-user obatos2015@gmail.com \
+ *     --other-uid hnNwP71qSKXJ1Hxi73qiiiOiVk13
+ *
+ * Requires GOOGLE_APPLICATION_CREDENTIALS or gcloud application-default login.
+ */
+
+import * as admin from 'firebase-admin';
+
+function parseArgs(argv: string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const next = argv[i + 1];
+      if (next && !next.startsWith('--')) {
+        out[key] = next;
+        i++;
+      } else {
+        out[key] = 'true';
+      }
+    }
+  }
+  return out;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const projectId = args.project ?? 'naijasingles-74a75';
+  const emailUser = args['email-user'];
+  const otherUid = args['other-uid'];
+  const emailUidArg = args['email-uid'];
+
+  if ((!emailUser && !emailUidArg) || !otherUid) {
+    console.error(
+      'Usage: npx ts-node src/scripts/seedTestChatThread.ts ' +
+        '--project naijasingles-74a75 ' +
+        '(--email-user EMAIL | --email-uid UID) --other-uid UID'
+    );
+    process.exit(1);
+  }
+
+  admin.initializeApp({projectId});
+  const auth = admin.auth();
+  const db = admin.firestore();
+
+  const emailUid = emailUidArg
+    ? emailUidArg
+    : (await auth.getUserByEmail(emailUser!)).uid;
+
+  if (emailUid === otherUid) {
+    throw new Error('email-user and other-uid must be different accounts');
+  }
+
+  const [emailDoc, otherDoc] = await Promise.all([
+    db.collection('users').doc(emailUid).get(),
+    db.collection('users').doc(otherUid).get(),
+  ]);
+
+  const emailName =
+    (emailDoc.data()?.name as string | undefined)?.trim() ||
+    (emailUser ? emailUser.split('@')[0] : undefined);
+  const otherName = (otherDoc.data()?.name as string | undefined)?.trim();
+
+  if (!emailName) {
+    throw new Error(
+      `users/${emailUid} has no name — set a profile name before seeding`,
+    );
+  }
+  if (!otherName) {
+    throw new Error(
+      `users/${otherUid} has no name — set a profile name before seeding ` +
+        `(do not use a placeholder like "Phone User")`,
+    );
+  }
+
+  const firstPhoto = (data: Record<string, unknown> | undefined): string | undefined => {
+    if (!data) return undefined;
+    for (const key of ['photos', 'Pictures']) {
+      const list = data[key];
+      if (Array.isArray(list) && list.length > 0 && typeof list[0] === 'string') {
+        return list[0];
+      }
+    }
+    return undefined;
+  };
+
+  const emailAvatar = firstPhoto(emailDoc.data() as Record<string, unknown> | undefined);
+  const otherAvatar = firstPhoto(otherDoc.data() as Record<string, unknown> | undefined);
+  const userAvatars: Record<string, string> = {};
+  if (emailAvatar) userAvatars[emailUid] = emailAvatar;
+  if (otherAvatar) userAvatars[otherUid] = otherAvatar;
+
+  const threadRef = db.collection('chatThreads').doc();
+  const now = admin.firestore.FieldValue.serverTimestamp();
+
+  await threadRef.set({
+    userIds: [emailUid, otherUid],
+    userNames: {
+      [emailUid]: emailName,
+      [otherUid]: otherName,
+    },
+    ...(Object.keys(userAvatars).length > 0 ? {userAvatars} : {}),
+    lastMessage: null,
+    lastMessageText: 'You matched! Say hello!',
+    lastMessageSenderId: null,
+    lastUpdated: now,
+    createdAt: now,
+    unreadCount: {
+      [emailUid]: 0,
+      [otherUid]: 0,
+    },
+  });
+
+  const matchRef = db.collection('matches').doc();
+  await matchRef.set({
+    users: [emailUid, otherUid],
+    matchedAt: now,
+    chatThreadId: threadRef.id,
+    matchStatus: 'matched',
+  });
+
+  // Legacy per-user Matches mirrors unlock canReadUserProfile for chat.
+  await Promise.all([
+    db.collection('users').doc(emailUid).collection('Matches').doc(otherUid).set({
+      Matches: otherUid,
+      userId: otherUid,
+      timestamp: now,
+    }),
+    db.collection('users').doc(otherUid).collection('Matches').doc(emailUid).set({
+      Matches: emailUid,
+      userId: emailUid,
+      timestamp: now,
+    }),
+  ]);
+
+  console.log('✅ Seeded test chat thread');
+  console.log(`   project:     ${projectId}`);
+  console.log(`   email user:  ${emailUser ?? emailUid} (${emailUid})`);
+  console.log(`   other uid:   ${otherUid} (${otherName})`);
+  console.log(`   chatThread:  chatThreads/${threadRef.id}`);
+  console.log(`   match:       matches/${matchRef.id}`);
+  console.log(`   mirrors:     users/*/Matches/*`);
+}
+
+main().catch((err) => {
+  console.error('❌ seedTestChatThread failed:', err);
+  process.exit(1);
+});

--- a/lib/common/data/repo/privacy_aware_user_search_repo.dart
+++ b/lib/common/data/repo/privacy_aware_user_search_repo.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 
+import '../../../features/discovery/data/services/discovery_filtering.dart';
 import '../../../models/user_model.dart';
 import '../../../services/location_privacy_service.dart';
 import '../../../services/user_privacy_service.dart';
@@ -92,18 +93,34 @@ class PrivacyAwareUserSearchRepo {
         userList = await _getFallbackUsers(currentUser, checkedUserIds);
       }
 
-      // Apply intent filtering in-memory (same logic as the unified path).
-      if (effectiveIntent != null &&
-          effectiveIntent.isNotEmpty &&
-          effectiveIntent != 'Mixed') {
-        userList = userList
-            .where(
-              (u) =>
-                  u.lookingFor == null ||
-                  u.lookingFor == effectiveIntent ||
-                  u.lookingFor == 'Mixed',
-            )
-            .toList();
+      final int beforeGender = userList.length;
+      userList = userList
+          .where(
+            (UserModel u) =>
+                DiscoveryFiltering.matchesGenderPreference(u, currentUser),
+          )
+          .toList();
+      if (beforeGender != userList.length) {
+        debugPrint(
+          '📋 Gender filter (${currentUser.showGender}): '
+          '$beforeGender → ${userList.length}',
+        );
+      }
+
+      final int beforeIntent = userList.length;
+      userList = userList
+          .where(
+            (UserModel u) => DiscoveryFiltering.matchesLookingForIntent(
+              u,
+              effectiveIntent,
+            ),
+          )
+          .toList();
+      if (beforeIntent != userList.length) {
+        debugPrint(
+          '📋 Intent filter ($effectiveIntent): '
+          '$beforeIntent → ${userList.length}',
+        );
       }
 
       AppLogger.debug('Privacy-aware list size: ${userList.length}');
@@ -224,7 +241,12 @@ class PrivacyAwareUserSearchRepo {
           if (calculatedDistance <= currentUser.maxDistance! &&
               temp.id != currentUser.id &&
               !temp.isBlocked!) {
-            debugPrint('📋 Adding fallback user: ${temp.name}');
+            debugPrint(
+              '📋 Adding fallback user: ${temp.name} '
+              '(lookingFor=${temp.lookingFor}, '
+              'gender=${temp.userGender}, '
+              'distance=${temp.distanceBW})',
+            );
             userList.add(temp);
           }
         } on Object catch (e) {
@@ -310,7 +332,10 @@ class PrivacyAwareUserSearchRepo {
       longitude: longitude,
       imageUrl: _extractPhotos(data),
       isBlocked: data['isBlocked'] ?? false,
-      lookingFor: data['lookingFor']?.toString() ?? 'Dating',
+      lookingFor: () {
+        final raw = data['lookingFor']?.toString().trim();
+        return (raw == null || raw.isEmpty) ? 'Dating' : raw;
+      }(),
       bio: data['bio']?.toString(),
       accountStatus: data['accountStatus']?.toString(),
     );

--- a/lib/common/data/repo/user_search_repo.dart
+++ b/lib/common/data/repo/user_search_repo.dart
@@ -2,14 +2,15 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 
+import '../../../features/discovery/data/services/discovery_filtering.dart';
 import '../../../features/discovery/data/services/discovery_service.dart';
 import '../../../features/match/data/services/match_service.dart';
 import '../../../models/user_model.dart';
 import '../../../services/cached_user_service.dart';
 import '../../../services/paginated_user_service.dart';
-import 'discovery_boost_sort.dart';
 import '../../constants/constants.dart';
 import '../../utils/distance.dart' as distance;
+import 'discovery_boost_sort.dart';
 
 class UserSearchRepo {
   static FirebaseFirestore db = firebaseFireStoreInstance;
@@ -352,19 +353,15 @@ class UserSearchRepo {
           }
 
           // Apply intent filter if specified.
-          // 'Mixed' users appear in every mode; a 'Mixed' filter shows all.
-          if (intentFilter != null &&
-              intentFilter.isNotEmpty &&
-              intentFilter != 'Mixed') {
-            final userIntent = temp.lookingFor;
-            if (userIntent != null &&
-                userIntent != intentFilter &&
-                userIntent != 'Mixed') {
-              debugPrint(
-                'Filtered out user: ${temp.name} (intent: $userIntent, looking for: $intentFilter)',
-              );
-              continue;
-            }
+          if (!DiscoveryFiltering.matchesLookingForIntent(
+            temp,
+            intentFilter,
+          )) {
+            debugPrint(
+              'Filtered out user: ${temp.name} '
+              '(intent: ${temp.lookingFor}, looking for: $intentFilter)',
+            );
+            continue;
           }
 
           if (distance <= currentUser.maxDistance! &&

--- a/lib/common/widgets/custom_snackbar.dart
+++ b/lib/common/widgets/custom_snackbar.dart
@@ -47,6 +47,26 @@ class CustomSnackbar {
       );
   }
 
+  /// Short, non-blocking toast (no DISMISS) for success / soft feedback.
+  static void showSnackBarQuiet(String msg, BuildContext context) {
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger == null) return;
+
+    messenger
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          duration: const Duration(seconds: 2),
+          backgroundColor: Colors.black87,
+          behavior: SnackBarBehavior.floating,
+          content: Text(
+            msg,
+            style: GoogleFonts.montserrat(color: Colors.white),
+          ),
+        ),
+      );
+  }
+
   // static showSnackBarSimple(msg, context) {
   //   ScaffoldMessenger.of(context).removeCurrentSnackBar();
   //   ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/dating/screens/user_detail_screen.dart
+++ b/lib/features/dating/screens/user_detail_screen.dart
@@ -42,7 +42,8 @@ class _UserDetailScreenState extends State<UserDetailScreen> {
 
   // MVP theme colors
   static const Color afropeepGreen = Color(0xFF008037); // MVP green
-  static const Color cardBackground = Color(0xFFF7E8DA);
+  /// Card fill matches profile sheet (white) — avoid peach mismatch with screen.
+  static const Color cardBackground = Colors.white;
   static const Color textDarkBrown = Color(0xFF3A1D0F);
   static const Color textLightBrown = Color(0xFF8B6C59);
 
@@ -702,7 +703,7 @@ class _UserDetailScreenState extends State<UserDetailScreen> {
           decoration: BoxDecoration(
             color: cardBackground,
             borderRadius: BorderRadius.circular(16),
-            border: Border.all(color: Colors.grey.shade300),
+            border: Border.all(color: Colors.grey.shade200),
           ),
           child: Text(
             bio,
@@ -818,7 +819,7 @@ class _UserDetailScreenState extends State<UserDetailScreen> {
         decoration: BoxDecoration(
           color: cardBackground,
           borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: Colors.grey.shade300),
+          border: Border.all(color: Colors.grey.shade200),
         ),
         child: Row(
           children: [

--- a/lib/features/discovery/data/services/discovery_filtering.dart
+++ b/lib/features/discovery/data/services/discovery_filtering.dart
@@ -42,10 +42,12 @@ class DiscoveryFiltering {
 
     switch (normalized) {
       case 'man':
+      case 'men':
       case 'male':
       case 'm':
         return 'male';
       case 'woman':
+      case 'women':
       case 'female':
       case 'f':
         return 'female';

--- a/lib/features/discovery/data/services/discovery_filtering.dart
+++ b/lib/features/discovery/data/services/discovery_filtering.dart
@@ -17,8 +17,7 @@ class DiscoveryFiltering {
     UserModel candidate,
     String? intentFilter,
   ) {
-    final String seeker =
-        (intentFilter ?? '').trim().toLowerCase();
+    final String seeker = (intentFilter ?? '').trim().toLowerCase();
     if (seeker.isEmpty || seeker == 'mixed') {
       return true;
     }

--- a/lib/features/discovery/data/services/discovery_filtering.dart
+++ b/lib/features/discovery/data/services/discovery_filtering.dart
@@ -2,6 +2,39 @@ import '../../../../models/user_model.dart';
 
 /// Shared filtering helpers for discovery queries and stream pipelines.
 class DiscoveryFiltering {
+  /// Synonyms accepted when the seeker filters by a primary intent.
+  static const Map<String, Set<String>> _intentSynonyms = {
+    'dating': {'dating', 'romance', 'relationship', 'love', 'marriage'},
+    'friendship': {'friendship', 'friends', 'social'},
+    'networking': {'networking', 'business', 'professional'},
+  };
+
+  /// Whether [candidate] should appear for the seeker's [intentFilter].
+  ///
+  /// Missing/blank/`Mixed` intents are treated as compatible so incomplete
+  /// profiles (common after migration) are not wiped from the deck.
+  static bool matchesLookingForIntent(
+    UserModel candidate,
+    String? intentFilter,
+  ) {
+    final String seeker =
+        (intentFilter ?? '').trim().toLowerCase();
+    if (seeker.isEmpty || seeker == 'mixed') {
+      return true;
+    }
+
+    final String theirs = (candidate.lookingFor ?? '').trim().toLowerCase();
+    if (theirs.isEmpty || theirs == 'mixed') {
+      return true;
+    }
+    if (theirs == seeker) {
+      return true;
+    }
+
+    final Set<String>? synonyms = _intentSynonyms[seeker];
+    return synonyms != null && synonyms.contains(theirs);
+  }
+
   /// Normalize gender values from profile/query fields to a common form.
   static String normalizeGender(String? value) {
     final normalized = value?.trim().toLowerCase() ?? '';

--- a/lib/features/discovery/presentation/screens/discovery_preferences_screen.dart
+++ b/lib/features/discovery/presentation/screens/discovery_preferences_screen.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:google_fonts/google_fonts.dart';
 
@@ -51,6 +54,10 @@ class _DiscoveryPreferencesScreenState
   bool _strictDistance = false;
   bool _strictIntent = false;
   bool _verifiedOnly = false;
+
+  /// Brief in-button confirmation after a successful apply (no snackbar).
+  bool _showAppliedConfirm = false;
+  Timer? _appliedConfirmTimer;
 
   /// Bumps when filters reset so [LookingForConnectionCard] rebuilds its selection.
   int _lookingForCardKey = 0;
@@ -166,6 +173,12 @@ class _DiscoveryPreferencesScreenState
     }
   }
 
+  @override
+  void dispose() {
+    _appliedConfirmTimer?.cancel();
+    super.dispose();
+  }
+
   void _resetFilters() {
     setState(() {
       changeValues.clear();
@@ -210,10 +223,7 @@ class _DiscoveryPreferencesScreenState
 
   void _applyFilters() {
     if (!_hasPendingEdits()) {
-      CustomSnackbar.showSnackBarSimple(
-        'No changes to save'.tr(),
-        context,
-      );
+      // Silent no-op (Tinder/Hinge-style) — no dismissible snackbar.
       return;
     }
     context.read<UserfilterBloc>().add(
@@ -234,16 +244,20 @@ class _DiscoveryPreferencesScreenState
             context,
           );
         } else if (state is UserFilterUpdated) {
-          CustomSnackbar.showSnackBarSimple(
-            'Preferences updated'.tr(),
-            context,
-          );
+          unawaited(HapticFeedback.lightImpact());
           changeValues.clear();
+          _appliedConfirmTimer?.cancel();
           setState(() {
             _strictAge = false;
             _strictDistance = false;
             _strictIntent = false;
             _verifiedOnly = false;
+            _showAppliedConfirm = true;
+          });
+          _appliedConfirmTimer = Timer(const Duration(milliseconds: 1600), () {
+            if (mounted) {
+              setState(() => _showAppliedConfirm = false);
+            }
           });
         }
       },
@@ -453,22 +467,47 @@ class _DiscoveryPreferencesScreenState
                   child: SizedBox(
                     width: double.infinity,
                     child: ElevatedButton(
-                      onPressed: _applyFilters,
+                      onPressed: _showAppliedConfirm ? null : _applyFilters,
                       style: ElevatedButton.styleFrom(
-                        backgroundColor: AppColors.primaryGreen,
+                        backgroundColor: _showAppliedConfirm
+                            ? AppColors.primaryGreen.withValues(alpha: 0.85)
+                            : AppColors.primaryGreen,
                         foregroundColor: Colors.white,
+                        disabledBackgroundColor:
+                            AppColors.primaryGreen.withValues(alpha: 0.85),
+                        disabledForegroundColor: Colors.white,
                         elevation: 0,
                         padding: const EdgeInsets.symmetric(vertical: 16),
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(12),
                         ),
                       ),
-                      child: Text(
-                        'Apply filters'.tr(),
-                        style: GoogleFonts.montserrat(
-                          fontSize: 16,
-                          fontWeight: FontWeight.w600,
-                        ),
+                      child: AnimatedSwitcher(
+                        duration: const Duration(milliseconds: 200),
+                        child: _showAppliedConfirm
+                            ? Row(
+                                key: const ValueKey<String>('applied'),
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  const Icon(Icons.check, size: 20),
+                                  const SizedBox(width: 8),
+                                  Text(
+                                    'Applied'.tr(),
+                                    style: GoogleFonts.montserrat(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                  ),
+                                ],
+                              )
+                            : Text(
+                                key: const ValueKey<String>('apply'),
+                                'Apply filters'.tr(),
+                                style: GoogleFonts.montserrat(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
                       ),
                     ),
                   ),

--- a/lib/features/home/bloc/searchuser_bloc.dart
+++ b/lib/features/home/bloc/searchuser_bloc.dart
@@ -28,6 +28,18 @@ class SearchUserBloc extends Bloc<SearchUserEvent, SearchUserState> {
         );
         discoverLoadTimer.stop();
 
+        if (userList.isEmpty) {
+          final user = event.currentUser;
+          log(
+            '📭 Discovery empty — showGender=${user.showGender}, '
+            'lookingFor=${user.lookingFor}, '
+            'maxDistanceKm=${user.maxDistance}, '
+            'ageRange=${user.ageRange}, '
+            'lat=${user.latitude}, lng=${user.longitude}, '
+            'address=${user.address}',
+          );
+        }
+
         final currentUserId = event.currentUser.id;
         final mode = event.currentUser.lookingFor ?? 'Dating';
         if (currentUserId != null) {

--- a/lib/features/home/ui/widgets/subscription_dialog.dart
+++ b/lib/features/home/ui/widgets/subscription_dialog.dart
@@ -65,8 +65,7 @@ Future<void> showSubscriptionDialog({
                                 create: (_) => GetInAppProductsBloc(),
                               ),
                               BlocProvider(
-                                create: (_) =>
-                                    BuyConsumableInAppProductsBloc(),
+                                create: (_) => BuyConsumableInAppProductsBloc(),
                               ),
                             ],
                             child: Products(currentUser, null, items),

--- a/lib/features/home/ui/widgets/subscription_dialog.dart
+++ b/lib/features/home/ui/widgets/subscription_dialog.dart
@@ -2,9 +2,12 @@ import 'dart:async';
 
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import '../../../../common/constants/app_colors.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
+import '../../../../common/constants/app_colors.dart';
 import '../../../../models/user_model.dart';
+import '../../../payment/ui/in_app_purchase/buy_products/buyproducts_bloc.dart';
+import '../../../payment/ui/in_app_purchase/get_products/getproducts_bloc.dart';
 import '../../../payment/ui/products.dart';
 
 Future<void> showSubscriptionDialog({
@@ -56,8 +59,18 @@ Future<void> showSubscriptionDialog({
                       Navigator.push(
                         context,
                         MaterialPageRoute(
-                          builder: (context) =>
-                              Products(currentUser, null, items),
+                          builder: (context) => MultiBlocProvider(
+                            providers: [
+                              BlocProvider(
+                                create: (_) => GetInAppProductsBloc(),
+                              ),
+                              BlocProvider(
+                                create: (_) =>
+                                    BuyConsumableInAppProductsBloc(),
+                              ),
+                            ],
+                            child: Products(currentUser, null, items),
+                          ),
                         ),
                       ),
                     );

--- a/lib/features/home/ui/widgets/swipe_card_list.dart
+++ b/lib/features/home/ui/widgets/swipe_card_list.dart
@@ -77,7 +77,8 @@ class _SwipeCardListState extends State<SwipeCardList> {
                   ? AppEmptyView(
                       title: "There's no one new around you.".tr().toString(),
                       subtitle:
-                          'Try expanding your distance or refreshing discovery.',
+                          'Widen distance, set Show me to Everyone, or choose '
+                          'All of the Above under looking for — then refresh.',
                       icon: Icons.explore_off,
                       actionLabel: 'Refresh',
                       onAction: () {

--- a/lib/features/home/ui/widgets/update_address.dart
+++ b/lib/features/home/ui/widgets/update_address.dart
@@ -155,7 +155,7 @@ class _UpdateAddressWidgetState extends State<UpdateAddressWidget> {
                     ),
                   ),
                   onTap: () async {
-                    log('hasSubscription $widget.hasSubscription');
+                    log('hasSubscription ${widget.hasSubscription}');
                     if (widget.hasSubscription) {
                       final address = await Navigator.pushNamed(
                         context,

--- a/lib/features/messages/chat_thread_screen.dart
+++ b/lib/features/messages/chat_thread_screen.dart
@@ -102,8 +102,7 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
         otherUserId: otherUserId,
       );
 
-      final ParticipantDisplayInfo display =
-          await _participantResolver.resolve(
+      final ParticipantDisplayInfo display = await _participantResolver.resolve(
         userId: otherUserId,
         cachedName: widget.userName,
         cachedAvatarUrl: widget.avatarUrl,

--- a/lib/features/messages/chat_thread_screen.dart
+++ b/lib/features/messages/chat_thread_screen.dart
@@ -19,6 +19,7 @@ import '../dating/screens/user_detail_screen.dart';
 import 'message_model.dart';
 import 'services/chat_service.dart';
 import 'services/matched_user_profile_loader.dart';
+import 'services/participant_profile_resolver.dart';
 import 'widgets/pre_meet_safety_sheet.dart';
 
 class ChatThreadScreen extends StatefulWidget {
@@ -44,6 +45,8 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
   final ChatService _chatService = ChatService();
   final MediaSharingService _mediaService = MediaSharingService();
   final ImagePicker _imagePicker = ImagePicker();
+  final ParticipantProfileResolver _participantResolver =
+      ParticipantProfileResolver();
   String? _currentUserId;
   bool _hasText = false;
   Timer? _typingDebounce;
@@ -51,11 +54,17 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
   String _searchQuery = '';
   String? _replyToMessageId;
   String? _replyPreview;
+  int _lastMessageCount = 0;
+  String? _lastMessageId;
+  late String _displayName;
+  String? _displayAvatarUrl;
 
   @override
   void initState() {
     super.initState();
     _currentUserId = FirebaseAuth.instance.currentUser?.uid;
+    _displayName = widget.userName;
+    _displayAvatarUrl = widget.avatarUrl;
 
     // Listen to text changes for send button animation
     _messageController.addListener(() {
@@ -73,11 +82,56 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
     });
 
     unawaited(_chatService.markThreadAsRead(widget.threadId));
+    unawaited(_resolveParticipantDisplay());
 
     // Scroll to bottom when messages load
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _scrollToBottom();
     });
+  }
+
+  Future<void> _resolveParticipantDisplay() async {
+    final String? otherUserId = widget.otherUserId;
+    if (otherUserId == null || otherUserId.isEmpty) {
+      return;
+    }
+
+    try {
+      await _participantResolver.ensureMatchMirrors(
+        currentUserId: _currentUserId ?? '',
+        otherUserId: otherUserId,
+      );
+
+      final ParticipantDisplayInfo display =
+          await _participantResolver.resolve(
+        userId: otherUserId,
+        cachedName: widget.userName,
+        cachedAvatarUrl: widget.avatarUrl,
+      );
+
+      if (!mounted) return;
+
+      setState(() {
+        _displayName = display.name;
+        _displayAvatarUrl = display.avatarUrl ?? widget.avatarUrl;
+      });
+
+      if (display.fromLiveProfile &&
+          !ParticipantProfileResolver.isPlaceholderName(display.name)) {
+        unawaited(
+          _participantResolver.writeThroughThreadCache(
+            threadId: widget.threadId,
+            userId: otherUserId,
+            name: display.name,
+            avatarUrl: display.avatarUrl,
+            cachedName: widget.userName,
+            cachedAvatarUrl: widget.avatarUrl,
+          ),
+        );
+      }
+    } on Object catch (e) {
+      log('Error resolving chat participant display: $e');
+    }
   }
 
   @override
@@ -179,8 +233,8 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
                 tag: 'avatar-${widget.threadId}',
                 child: CircleAvatar(
                   radius: 16,
-                  backgroundImage: widget.avatarUrl != null
-                      ? NetworkImage(widget.avatarUrl ?? '')
+                  backgroundImage: _displayAvatarUrl != null
+                      ? NetworkImage(_displayAvatarUrl ?? '')
                       : const AssetImage(
                           'assets/images/placeholder_profile.jpg',
                         ) as ImageProvider,
@@ -194,7 +248,7 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     Text(
-                      widget.userName,
+                      _displayName,
                       style: GoogleFonts.montserrat(
                         // Use Montserrat for MVP
                         fontSize: 16,
@@ -329,14 +383,23 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
                 if (messages.isEmpty) {
                   return AppEmptyView(
                     title: 'No Messages Yet',
-                    subtitle: 'Say hi to ${widget.userName}!',
+                    subtitle: 'Say hi to $_displayName!',
                     icon: Icons.chat_bubble_outline,
                   );
                 }
 
-                WidgetsBinding.instance.addPostFrameCallback((_) {
-                  _scrollToBottom();
-                });
+                final String? newestId =
+                    messages.isNotEmpty ? messages.last.id : null;
+                final bool shouldScroll =
+                    messages.length != _lastMessageCount ||
+                        newestId != _lastMessageId;
+                if (shouldScroll) {
+                  _lastMessageCount = messages.length;
+                  _lastMessageId = newestId;
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    _scrollToBottom();
+                  });
+                }
 
                 return ListView.builder(
                   controller: _scrollController,
@@ -359,7 +422,7 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
                       timestamp: message.timestamp,
                       senderId: message.senderId,
                       isOwnMessage: isMe,
-                      senderAvatarUrl: isMe ? null : widget.avatarUrl,
+                      senderAvatarUrl: isMe ? null : _displayAvatarUrl,
                       isRead: message.isRead,
                       showReadReceipt: true,
                       imageUrl: message.imageUrl,
@@ -609,9 +672,35 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
       final userModel = await MatchedUserProfileLoader.load(
         firestore: FirebaseFirestore.instance,
         userId: widget.otherUserId!,
-        fallbackName: widget.userName,
-        fallbackAvatarUrl: widget.avatarUrl,
+        fallbackName: _displayName,
+        fallbackAvatarUrl: _displayAvatarUrl,
       );
+
+      final String? loadedName = userModel.name;
+      final String? loadedAvatar =
+          (userModel.imageUrl != null && userModel.imageUrl!.isNotEmpty)
+              ? userModel.imageUrl!.first as String?
+              : null;
+      if (loadedName != null && loadedName.trim().isNotEmpty) {
+        unawaited(
+          _participantResolver.writeThroughThreadCache(
+            threadId: widget.threadId,
+            userId: widget.otherUserId!,
+            name: loadedName.trim(),
+            avatarUrl: loadedAvatar,
+            cachedName: _displayName,
+            cachedAvatarUrl: _displayAvatarUrl,
+          ),
+        );
+        if (mounted) {
+          setState(() {
+            _displayName = loadedName.trim();
+            if (loadedAvatar != null && loadedAvatar.isNotEmpty) {
+              _displayAvatarUrl = loadedAvatar;
+            }
+          });
+        }
+      }
 
       if (mounted) {
         Navigator.pop(context);
@@ -644,8 +733,8 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
 
       final fallbackUser = MatchedUserProfileLoader.buildFallback(
         userId: widget.otherUserId!,
-        fallbackName: widget.userName,
-        fallbackAvatarUrl: widget.avatarUrl,
+        fallbackName: _displayName,
+        fallbackAvatarUrl: _displayAvatarUrl,
       );
 
       unawaited(
@@ -739,7 +828,7 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
 
               // Title with Poppins font
               Text(
-                'Block ${widget.userName}?',
+                'Block $_displayName?',
                 style: GoogleFonts.montserrat(
                   fontSize: 20,
                   fontWeight: FontWeight.w600,
@@ -894,7 +983,7 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
                 ),
                 const SizedBox(height: 20),
                 Text(
-                  'Report ${widget.userName}?',
+                  'Report $_displayName?',
                   style: GoogleFonts.montserrat(
                     fontSize: 20,
                     fontWeight: FontWeight.w600,
@@ -1367,7 +1456,7 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
                   const SizedBox(width: 12),
                   Expanded(
                     child: Text(
-                      '${widget.userName} has been blocked',
+                      '$_displayName has been blocked',
                       style: GoogleFonts.montserrat(
                         color: Colors.white,
                         fontWeight: FontWeight.w500,

--- a/lib/features/messages/message_model.dart
+++ b/lib/features/messages/message_model.dart
@@ -52,8 +52,7 @@ class MessageThreadInfo {
         otherUserId: otherUserId ?? this.otherUserId,
         otherUserName: otherUserName ?? this.otherUserName,
         lastMessage: lastMessage ?? this.lastMessage,
-        lastMessageSenderId:
-            lastMessageSenderId ?? this.lastMessageSenderId,
+        lastMessageSenderId: lastMessageSenderId ?? this.lastMessageSenderId,
         timestamp: timestamp ?? this.timestamp,
         unread: unread ?? this.unread,
         avatarUrl: avatarUrl ?? this.avatarUrl,

--- a/lib/features/messages/message_model.dart
+++ b/lib/features/messages/message_model.dart
@@ -37,6 +37,28 @@ class MessageThreadInfo {
   final bool unread;
   final String? avatarUrl;
 
+  MessageThreadInfo copyWith({
+    String? threadId,
+    String? otherUserId,
+    String? otherUserName,
+    String? lastMessage,
+    String? lastMessageSenderId,
+    DateTime? timestamp,
+    bool? unread,
+    String? avatarUrl,
+  }) =>
+      MessageThreadInfo(
+        threadId: threadId ?? this.threadId,
+        otherUserId: otherUserId ?? this.otherUserId,
+        otherUserName: otherUserName ?? this.otherUserName,
+        lastMessage: lastMessage ?? this.lastMessage,
+        lastMessageSenderId:
+            lastMessageSenderId ?? this.lastMessageSenderId,
+        timestamp: timestamp ?? this.timestamp,
+        unread: unread ?? this.unread,
+        avatarUrl: avatarUrl ?? this.avatarUrl,
+      );
+
   // Helper method to format timestamp as relative time
   String getRelativeTime() {
     final now = DateTime.now();

--- a/lib/features/messages/messages_screen.dart
+++ b/lib/features/messages/messages_screen.dart
@@ -14,6 +14,7 @@ import 'chat_thread_screen.dart';
 import 'message_model.dart';
 import 'services/chat_service.dart';
 import 'services/matched_user_profile_loader.dart';
+import 'services/participant_profile_resolver.dart';
 
 class MessagesScreen extends StatefulWidget {
   const MessagesScreen({super.key});
@@ -25,6 +26,8 @@ class MessagesScreen extends StatefulWidget {
 class _MessagesScreenState extends State<MessagesScreen> {
   final ChatService _chatService = ChatService();
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final ParticipantProfileResolver _participantResolver =
+      ParticipantProfileResolver();
 
   @override
   Widget build(BuildContext context) => Scaffold(
@@ -653,6 +656,24 @@ class _MessagesScreenState extends State<MessagesScreen> {
         fallbackName: thread.otherUserName,
         fallbackAvatarUrl: thread.avatarUrl,
       );
+
+      final String? loadedName = userModel.name;
+      final String? loadedAvatar =
+          (userModel.imageUrl != null && userModel.imageUrl!.isNotEmpty)
+              ? userModel.imageUrl!.first as String?
+              : null;
+      if (loadedName != null && loadedName.trim().isNotEmpty) {
+        unawaited(
+          _participantResolver.writeThroughThreadCache(
+            threadId: thread.threadId,
+            userId: thread.otherUserId,
+            name: loadedName.trim(),
+            avatarUrl: loadedAvatar,
+            cachedName: thread.otherUserName,
+            cachedAvatarUrl: thread.avatarUrl,
+          ),
+        );
+      }
 
       if (mounted && Navigator.canPop(context)) {
         Navigator.pop(context);

--- a/lib/features/messages/services/chat_service.dart
+++ b/lib/features/messages/services/chat_service.dart
@@ -9,6 +9,7 @@ import '../../../features/match/data/analytics/match_quality_reporter.dart';
 import '../../../services/performance_monitor.dart';
 import '../message_model.dart';
 import 'conversation_quality_metrics.dart';
+import 'participant_profile_resolver.dart';
 
 class ChatService {
   ChatService({
@@ -93,6 +94,9 @@ class ChatService {
 
       // Fetch both users' profiles in parallel for names and avatars
       String currentUserName = 'User';
+      String resolvedOtherUserName = otherUserName.trim().isNotEmpty
+          ? otherUserName.trim()
+          : 'User';
       String? currentUserAvatar;
       String? otherUserAvatar;
       try {
@@ -108,15 +112,29 @@ class ChatService {
           final photos = data?['photos'] as List<dynamic>?;
           if (photos != null && photos.isNotEmpty) {
             currentUserAvatar = photos.first as String?;
+          } else {
+            final pictures = data?['Pictures'] as List<dynamic>?;
+            if (pictures != null && pictures.isNotEmpty) {
+              currentUserAvatar = pictures.first as String?;
+            }
           }
         }
 
         final otherUserDoc = results[1];
         if (otherUserDoc.exists) {
           final data = otherUserDoc.data();
+          final liveName = data?['name'] as String?;
+          if (liveName != null && liveName.trim().isNotEmpty) {
+            resolvedOtherUserName = liveName.trim();
+          }
           final photos = data?['photos'] as List<dynamic>?;
           if (photos != null && photos.isNotEmpty) {
             otherUserAvatar = photos.first as String?;
+          } else {
+            final pictures = data?['Pictures'] as List<dynamic>?;
+            if (pictures != null && pictures.isNotEmpty) {
+              otherUserAvatar = pictures.first as String?;
+            }
           }
         }
       } on FirebaseException catch (e) {
@@ -140,11 +158,11 @@ class ChatService {
         'userIds': [currentUserId, otherUserId],
         'userNames': {
           currentUserId: currentUserName,
-          otherUserId: otherUserName,
+          otherUserId: resolvedOtherUserName,
         },
         if (userAvatars.isNotEmpty) 'userAvatars': userAvatars,
         'lastMessage': null,
-        'lastMessageText': 'Say hi to $otherUserName!',
+        'lastMessageText': 'Say hi to $resolvedOtherUserName!',
         'lastMessageSenderId': null,
         'lastUpdated': FieldValue.serverTimestamp(),
         'createdAt': FieldValue.serverTimestamp(),
@@ -729,7 +747,52 @@ class ChatService {
             .toList()
           ..sort((a, b) => b.timestamp.compareTo(a.timestamp));
 
-        return threads;
+        final ParticipantProfileResolver resolver =
+            ParticipantProfileResolver(firestore: _firestore);
+
+        final List<MessageThreadInfo> enriched = await Future.wait(
+          threads.map((thread) async {
+            try {
+              await resolver.ensureMatchMirrors(
+                currentUserId: userId,
+                otherUserId: thread.otherUserId,
+              );
+
+              final ParticipantDisplayInfo display = await resolver.resolve(
+                userId: thread.otherUserId,
+                cachedName: thread.otherUserName,
+                cachedAvatarUrl: thread.avatarUrl,
+              );
+
+              if (display.fromLiveProfile &&
+                  !ParticipantProfileResolver.isPlaceholderName(display.name)) {
+                unawaited(
+                  resolver.writeThroughThreadCache(
+                    threadId: thread.threadId,
+                    userId: thread.otherUserId,
+                    name: display.name,
+                    avatarUrl: display.avatarUrl,
+                    cachedName: thread.otherUserName,
+                    cachedAvatarUrl: thread.avatarUrl,
+                  ),
+                );
+              }
+
+              return thread.copyWith(
+                otherUserName: display.name,
+                avatarUrl: display.avatarUrl ?? thread.avatarUrl,
+              );
+            } on Object catch (e) {
+              AppLogger.error(
+                'Error enriching thread participant profile',
+                error: e,
+              );
+              return thread;
+            }
+          }),
+        );
+
+        return enriched;
       } on FirebaseException catch (e) {
         AppLogger.error(
           'Firebase error mapping chat threads: ${e.code} - ${e.message}',

--- a/lib/features/messages/services/chat_service.dart
+++ b/lib/features/messages/services/chat_service.dart
@@ -94,9 +94,8 @@ class ChatService {
 
       // Fetch both users' profiles in parallel for names and avatars
       String currentUserName = 'User';
-      String resolvedOtherUserName = otherUserName.trim().isNotEmpty
-          ? otherUserName.trim()
-          : 'User';
+      String resolvedOtherUserName =
+          otherUserName.trim().isNotEmpty ? otherUserName.trim() : 'User';
       String? currentUserAvatar;
       String? otherUserAvatar;
       try {

--- a/lib/features/messages/services/participant_profile_resolver.dart
+++ b/lib/features/messages/services/participant_profile_resolver.dart
@@ -97,8 +97,7 @@ class ParticipantProfileResolver {
     }
 
     try {
-      final bool matched =
-          await _hasTopLevelMatch(currentUserId, otherUserId);
+      final bool matched = await _hasTopLevelMatch(currentUserId, otherUserId);
       if (!matched) {
         return;
       }

--- a/lib/features/messages/services/participant_profile_resolver.dart
+++ b/lib/features/messages/services/participant_profile_resolver.dart
@@ -82,7 +82,10 @@ class ParticipantProfileResolver {
 
   /// Creates bidirectional `users/{uid}/Matches/{other}` mirrors so
   /// [canReadUserProfile] / [hasLegacyMatchWith] allow live profile reads.
-  /// Safe for seeded QA threads that only have top-level `matches` docs.
+  ///
+  /// Only writes after proving a top-level `matches` / legacy `Matches`
+  /// document exists for the pair — never invents match state from a chat
+  /// thread alone (seeded/forged threads must not gain profile-read access).
   Future<void> ensureMatchMirrors({
     required String currentUserId,
     required String otherUserId,
@@ -93,18 +96,24 @@ class ParticipantProfileResolver {
       return;
     }
 
-    final DocumentReference<Map<String, dynamic>> mine = _firestore
-        .collection('users')
-        .doc(currentUserId)
-        .collection('Matches')
-        .doc(otherUserId);
-    final DocumentReference<Map<String, dynamic>> theirs = _firestore
-        .collection('users')
-        .doc(otherUserId)
-        .collection('Matches')
-        .doc(currentUserId);
-
     try {
+      final bool matched =
+          await _hasTopLevelMatch(currentUserId, otherUserId);
+      if (!matched) {
+        return;
+      }
+
+      final DocumentReference<Map<String, dynamic>> mine = _firestore
+          .collection('users')
+          .doc(currentUserId)
+          .collection('Matches')
+          .doc(otherUserId);
+      final DocumentReference<Map<String, dynamic>> theirs = _firestore
+          .collection('users')
+          .doc(otherUserId)
+          .collection('Matches')
+          .doc(currentUserId);
+
       final List<DocumentSnapshot<Map<String, dynamic>>> snaps =
           await Future.wait(<Future<DocumentSnapshot<Map<String, dynamic>>>>[
         mine.get(),
@@ -136,6 +145,40 @@ class ParticipantProfileResolver {
     } on FirebaseException catch (_) {
       // Best-effort; profile resolve will fall back to thread cache.
     }
+  }
+
+  /// True when [userId1] and [userId2] appear together in top-level match docs.
+  Future<bool> _hasTopLevelMatch(String userId1, String userId2) async {
+    final QuerySnapshot<Map<String, dynamic>> modern = await _firestore
+        .collection('matches')
+        .where('users', arrayContains: userId1)
+        .get();
+    for (final QueryDocumentSnapshot<Map<String, dynamic>> doc in modern.docs) {
+      final List<String> users =
+          List<String>.from(doc.data()['users'] as List? ?? const <String>[]);
+      if (users.contains(userId2)) {
+        return true;
+      }
+    }
+
+    final QuerySnapshot<Map<String, dynamic>> legacy = await _firestore
+        .collection('Matches')
+        .where('users', arrayContains: userId1)
+        .get();
+    for (final QueryDocumentSnapshot<Map<String, dynamic>> doc in legacy.docs) {
+      final Map<String, dynamic> data = doc.data();
+      final List<String> users =
+          List<String>.from(data['users'] as List? ?? const <String>[]);
+      if (users.contains(userId2)) {
+        return true;
+      }
+      if ((data['user1'] == userId1 && data['user2'] == userId2) ||
+          (data['user1'] == userId2 && data['user2'] == userId1)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   /// Updates denormalized thread fields when live values differ from cache.

--- a/lib/features/messages/services/participant_profile_resolver.dart
+++ b/lib/features/messages/services/participant_profile_resolver.dart
@@ -1,0 +1,212 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Live name + avatar for a chat participant, with thread-cache fallback.
+class ParticipantDisplayInfo {
+  const ParticipantDisplayInfo({
+    required this.userId,
+    required this.name,
+    required this.fromLiveProfile,
+    this.avatarUrl,
+  });
+
+  final String userId;
+  final String name;
+  final String? avatarUrl;
+  final bool fromLiveProfile;
+}
+
+/// Resolves display identity from `users/{uid}`, falling back to thread cache.
+class ParticipantProfileResolver {
+  ParticipantProfileResolver({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  final FirebaseFirestore _firestore;
+
+  static const Set<String> _placeholderNames = <String>{
+    'phone user',
+    'user',
+    'unknown user',
+    'email user',
+    'someone',
+  };
+
+  /// True when [name] is empty or a known seed/placeholder label.
+  static bool isPlaceholderName(String? name) {
+    if (name == null) return true;
+    final String trimmed = name.trim();
+    if (trimmed.isEmpty) return true;
+    return _placeholderNames.contains(trimmed.toLowerCase());
+  }
+
+  /// Prefer live Firestore profile; on missing doc or permission-denied use cache.
+  Future<ParticipantDisplayInfo> resolve({
+    required String userId,
+    String? cachedName,
+    String? cachedAvatarUrl,
+  }) async {
+    final String? usableCache =
+        isPlaceholderName(cachedName) ? null : cachedName?.trim();
+    final String fallbackName = usableCache ?? 'User';
+
+    try {
+      final DocumentSnapshot<Map<String, dynamic>> doc =
+          await _firestore.collection('users').doc(userId).get();
+      if (doc.exists) {
+        final Map<String, dynamic>? data = doc.data();
+        final String? liveName = _readName(data);
+        final String? liveAvatar = _readFirstPhoto(data);
+        final String resolvedName =
+            (liveName != null && !isPlaceholderName(liveName))
+                ? liveName
+                : fallbackName;
+        return ParticipantDisplayInfo(
+          userId: userId,
+          name: resolvedName,
+          avatarUrl: liveAvatar ?? cachedAvatarUrl,
+          fromLiveProfile: true,
+        );
+      }
+    } on FirebaseException catch (e) {
+      if (e.code != 'permission-denied') {
+        rethrow;
+      }
+    }
+
+    return ParticipantDisplayInfo(
+      userId: userId,
+      name: fallbackName,
+      avatarUrl: cachedAvatarUrl,
+      fromLiveProfile: false,
+    );
+  }
+
+  /// Creates bidirectional `users/{uid}/Matches/{other}` mirrors so
+  /// [canReadUserProfile] / [hasLegacyMatchWith] allow live profile reads.
+  /// Safe for seeded QA threads that only have top-level `matches` docs.
+  Future<void> ensureMatchMirrors({
+    required String currentUserId,
+    required String otherUserId,
+  }) async {
+    if (currentUserId.isEmpty ||
+        otherUserId.isEmpty ||
+        currentUserId == otherUserId) {
+      return;
+    }
+
+    final DocumentReference<Map<String, dynamic>> mine = _firestore
+        .collection('users')
+        .doc(currentUserId)
+        .collection('Matches')
+        .doc(otherUserId);
+    final DocumentReference<Map<String, dynamic>> theirs = _firestore
+        .collection('users')
+        .doc(otherUserId)
+        .collection('Matches')
+        .doc(currentUserId);
+
+    try {
+      final List<DocumentSnapshot<Map<String, dynamic>>> snaps =
+          await Future.wait(<Future<DocumentSnapshot<Map<String, dynamic>>>>[
+        mine.get(),
+        theirs.get(),
+      ]);
+
+      final List<Future<void>> writes = <Future<void>>[];
+      if (!snaps[0].exists) {
+        writes.add(
+          mine.set(<String, Object?>{
+            'Matches': otherUserId,
+            'userId': otherUserId,
+            'timestamp': FieldValue.serverTimestamp(),
+          }),
+        );
+      }
+      if (!snaps[1].exists) {
+        writes.add(
+          theirs.set(<String, Object?>{
+            'Matches': currentUserId,
+            'userId': currentUserId,
+            'timestamp': FieldValue.serverTimestamp(),
+          }),
+        );
+      }
+      if (writes.isNotEmpty) {
+        await Future.wait(writes);
+      }
+    } on FirebaseException catch (_) {
+      // Best-effort; profile resolve will fall back to thread cache.
+    }
+  }
+
+  /// Updates denormalized thread fields when live values differ from cache.
+  Future<void> writeThroughThreadCache({
+    required String threadId,
+    required String userId,
+    required String name,
+    String? avatarUrl,
+    String? cachedName,
+    String? cachedAvatarUrl,
+  }) async {
+    if (isPlaceholderName(name)) {
+      return;
+    }
+
+    final bool nameChanged =
+        name != cachedName || isPlaceholderName(cachedName);
+    final bool avatarChanged = avatarUrl != null &&
+        avatarUrl.isNotEmpty &&
+        avatarUrl != cachedAvatarUrl;
+    if (!nameChanged && !avatarChanged) {
+      return;
+    }
+
+    final Map<String, Object?> updates = <String, Object?>{};
+    if (nameChanged) {
+      updates['userNames.$userId'] = name;
+    }
+    if (avatarChanged) {
+      updates['userAvatars.$userId'] = avatarUrl;
+    }
+
+    try {
+      await _firestore.collection('chatThreads').doc(threadId).update(updates);
+    } on FirebaseException catch (_) {
+      // Best-effort cache refresh; UI already shows live values.
+    }
+  }
+
+  static String? _readName(Map<String, dynamic>? data) {
+    if (data == null) return null;
+    for (final String key in <String>['name', 'UserName', 'displayName']) {
+      final Object? raw = data[key];
+      if (raw is String && raw.trim().isNotEmpty) {
+        final String trimmed = raw.trim();
+        if (!isPlaceholderName(trimmed)) {
+          return trimmed;
+        }
+      }
+    }
+    return null;
+  }
+
+  static String? _readFirstPhoto(Map<String, dynamic>? data) {
+    if (data == null) return null;
+    for (final String key in <String>['photos', 'Pictures']) {
+      final Object? raw = data[key];
+      if (raw is List && raw.isNotEmpty) {
+        final Object? first = raw.first;
+        if (first is String && first.isNotEmpty) {
+          return first;
+        }
+      }
+    }
+    return null;
+  }
+
+  /// Visible for unit tests.
+  static String? readNameForTest(Map<String, dynamic>? data) => _readName(data);
+
+  /// Visible for unit tests.
+  static String? readFirstPhotoForTest(Map<String, dynamic>? data) =>
+      _readFirstPhoto(data);
+}

--- a/lib/features/payment/ui/products.dart
+++ b/lib/features/payment/ui/products.dart
@@ -28,7 +28,7 @@ import 'in_app_purchase/get_products/getproducts_bloc.dart';
 import 'in_app_purchase/get_products/getproducts_events.dart';
 import 'in_app_purchase/get_products/getproducts_states.dart';
 
-class Products extends StatefulWidget {
+class Products extends StatelessWidget {
   const Products(
     this.currentUser,
     this.isPaymentSuccess,
@@ -40,10 +40,65 @@ class Products extends StatefulWidget {
   final Map items;
 
   @override
-  ProductsState createState() => ProductsState();
+  Widget build(BuildContext context) {
+    // Call sites sometimes push [Products] without IAP blocs (e.g. location
+    // upsell). Provide them here when missing so paywalls never red-screen.
+    final bool hasGetBloc = _blocAvailable<GetInAppProductsBloc>(context);
+    final bool hasBuyBloc =
+        _blocAvailable<BuyConsumableInAppProductsBloc>(context);
+
+    Widget child = _ProductsBody(
+      currentUser: currentUser,
+      isPaymentSuccess: isPaymentSuccess,
+      items: items,
+    );
+
+    if (!hasGetBloc || !hasBuyBloc) {
+      child = MultiBlocProvider(
+        providers: [
+          if (!hasGetBloc)
+            BlocProvider<GetInAppProductsBloc>(
+              create: (_) => GetInAppProductsBloc(),
+            ),
+          if (!hasBuyBloc)
+            BlocProvider<BuyConsumableInAppProductsBloc>(
+              create: (_) => BuyConsumableInAppProductsBloc(),
+            ),
+        ],
+        child: child,
+      );
+    }
+    return child;
+  }
+
+  static bool _blocAvailable<T extends StateStreamableSource<Object?>>(
+    BuildContext context,
+  ) {
+    try {
+      BlocProvider.of<T>(context, listen: false);
+      return true;
+    } on Object {
+      return false;
+    }
+  }
 }
 
-class ProductsState extends State<Products> {
+class _ProductsBody extends StatefulWidget {
+  const _ProductsBody({
+    required this.currentUser,
+    required this.isPaymentSuccess,
+    required this.items,
+  });
+
+  final bool? isPaymentSuccess;
+  final UserModel? currentUser;
+  final Map items;
+
+  @override
+  State<_ProductsBody> createState() => _ProductsBodyState();
+}
+
+class _ProductsBodyState extends State<_ProductsBody> {
   ProductDetails? selectedProduct;
 
   @override

--- a/lib/models/user_model.dart
+++ b/lib/models/user_model.dart
@@ -65,6 +65,12 @@ class UserModel {
     return DateTime.tryParse(value.toString());
   }
 
+  /// Blank/missing lookingFor is common after migration; default to Dating.
+  static String _resolveLookingFor(String? value) {
+    final String trimmed = (value ?? '').trim();
+    return trimmed.isEmpty ? 'Dating' : trimmed;
+  }
+
   factory UserModel.fromDocument(DocumentSnapshot doc) {
     try {
       // Get the document ID as the user ID
@@ -211,8 +217,10 @@ class UserModel {
             safeGetNested<String>('editInfo', 'smokingStatus', ''),
         lastSeen: parseDateTimeOrNull(data['lastSeen']) ??
             parseDateTimeOrNull(data['lastActive']),
-        lookingFor: safeGet<String>('lookingFor') ??
-            safeGetNested<String>('editInfo', 'lookingFor', 'Dating'),
+        lookingFor: _resolveLookingFor(
+          safeGet<String>('lookingFor') ??
+              safeGetNested<String>('editInfo', 'lookingFor'),
+        ),
         // Cultural fields
         nationality: safeGet<String>('nationality') ??
             safeGetNested<String>('editInfo', 'nationality', ''),
@@ -415,7 +423,7 @@ class UserModel {
         lastSeen: map['lastSeen'] != null
             ? DateTime.tryParse(map['lastSeen'].toString())
             : null,
-        lookingFor: map['lookingFor']?.toString() ?? 'Dating',
+        lookingFor: UserModel._resolveLookingFor(map['lookingFor']?.toString()),
         // Cultural fields
         nationality: map['nationality']?.toString(),
         tribe: map['tribe']?.toString(),

--- a/lib/services/mode_specific_filtering_service.dart
+++ b/lib/services/mode_specific_filtering_service.dart
@@ -1,5 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
+
+import '../features/discovery/data/services/discovery_filtering.dart';
 import '../models/user_model.dart';
 
 /// Mode-specific filtering service that applies different filters based on relationship intent
@@ -215,25 +217,15 @@ class ModeSpecificFilteringService {
 
   static bool _validateDatingMatch(UserModel user) {
     final imageCheck = user.imageUrl != null && user.imageUrl!.isNotEmpty;
-    final lookingForCheck = user.lookingFor == null ||
-        user.lookingFor == 'Dating' ||
-        user.lookingFor == 'Mixed';
-    return imageCheck && lookingForCheck;
+    return imageCheck &&
+        DiscoveryFiltering.matchesLookingForIntent(user, 'Dating');
   }
 
-  static bool _validateFriendshipMatch(UserModel user) {
-    final lookingForCheck = user.lookingFor == null ||
-        user.lookingFor == 'Friendship' ||
-        user.lookingFor == 'Mixed';
-    return lookingForCheck;
-  }
+  static bool _validateFriendshipMatch(UserModel user) =>
+      DiscoveryFiltering.matchesLookingForIntent(user, 'Friendship');
 
-  static bool _validateNetworkingMatch(UserModel user) {
-    final lookingForCheck = user.lookingFor == null ||
-        user.lookingFor == 'Networking' ||
-        user.lookingFor == 'Mixed';
-    return lookingForCheck;
-  }
+  static bool _validateNetworkingMatch(UserModel user) =>
+      DiscoveryFiltering.matchesLookingForIntent(user, 'Networking');
 
   /// Get mode-specific search suggestions
   static List<String> getModeSpecificSuggestions(String mode) {

--- a/scripts/seed_test_chat_thread.sh
+++ b/scripts/seed_test_chat_thread.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Seed chatThreads + matches for Messages-tab QA using gcloud + Firestore REST API.
+#
+# Usage:
+#   ./scripts/seed_test_chat_thread.sh
+#   ./scripts/seed_test_chat_thread.sh QcDPYcH7XBSM5nbHwDlUHoQlJVB3 hnNwP71qSKXJ1Hxi73qiiiOiVk13
+#
+# Requires: gcloud auth login (firebase/gcloud project access)
+set -euo pipefail
+
+PROJECT="${FIREBASE_PROJECT:-naijasingles-74a75}"
+EMAIL_UID="${1:-QcDPYcH7XBSM5nbHwDlUHoQlJVB3}"
+OTHER_UID="${2:-hnNwP71qSKXJ1Hxi73qiiiOiVk13}"
+NOW="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+if ! command -v gcloud >/dev/null 2>&1; then
+  echo "gcloud CLI is required. Install Google Cloud SDK first."
+  exit 1
+fi
+
+if ! gcloud auth list --filter=status:ACTIVE --format="value(account)" | grep -q .; then
+  echo "Run: gcloud auth login"
+  exit 1
+fi
+
+TOKEN="$(gcloud auth print-access-token)"
+BASE="https://firestore.googleapis.com/v1/projects/${PROJECT}/databases/(default)/documents"
+
+create_doc() {
+  local collection="$1"
+  local payload="$2"
+  curl -sS -X POST "${BASE}/${collection}" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "${payload}"
+}
+
+THREAD_PAYLOAD="$(cat <<EOF
+{
+  "fields": {
+    "userIds": {
+      "arrayValue": {
+        "values": [
+          {"stringValue": "${EMAIL_UID}"},
+          {"stringValue": "${OTHER_UID}"}
+        ]
+      }
+    },
+    "userNames": {
+      "mapValue": {
+        "fields": {
+          "${EMAIL_UID}": {"stringValue": "Obatos"},
+          "${OTHER_UID}": {"stringValue": "Phone User"}
+        }
+      }
+    },
+    "lastMessage": {"nullValue": null},
+    "lastMessageText": {"stringValue": "You matched! Say hello!"},
+    "lastMessageSenderId": {"nullValue": null},
+    "lastUpdated": {"timestampValue": "${NOW}"},
+    "createdAt": {"timestampValue": "${NOW}"},
+    "unreadCount": {
+      "mapValue": {
+        "fields": {
+          "${EMAIL_UID}": {"integerValue": "0"},
+          "${OTHER_UID}": {"integerValue": "0"}
+        }
+      }
+    }
+  }
+}
+EOF
+)"
+
+echo "Seeding chatThreads on ${PROJECT}..."
+THREAD_RESPONSE="$(create_doc "chatThreads" "${THREAD_PAYLOAD}")"
+
+if echo "${THREAD_RESPONSE}" | grep -q '"error"'; then
+  echo "❌ Failed to create chatThreads document:"
+  echo "${THREAD_RESPONSE}"
+  exit 1
+fi
+
+THREAD_ID="$(echo "${THREAD_RESPONSE}" | node -e "
+  let data = '';
+  process.stdin.on('data', (c) => (data += c));
+  process.stdin.on('end', () => {
+    const doc = JSON.parse(data);
+    const name = doc.name || '';
+    const id = name.split('/').pop();
+    console.log(id || '');
+  });
+")"
+
+if [[ -z "${THREAD_ID}" ]]; then
+  echo "❌ Could not parse chatThreads document ID"
+  echo "${THREAD_RESPONSE}"
+  exit 1
+fi
+
+MATCH_PAYLOAD="$(cat <<EOF
+{
+  "fields": {
+    "users": {
+      "arrayValue": {
+        "values": [
+          {"stringValue": "${EMAIL_UID}"},
+          {"stringValue": "${OTHER_UID}"}
+        ]
+      }
+    },
+    "matchedAt": {"timestampValue": "${NOW}"},
+    "chatThreadId": {"stringValue": "${THREAD_ID}"},
+    "matchStatus": {"stringValue": "matched"}
+  }
+}
+EOF
+)"
+
+echo "Seeding matches/${THREAD_ID} link..."
+MATCH_RESPONSE="$(create_doc "matches" "${MATCH_PAYLOAD}")"
+
+if echo "${MATCH_RESPONSE}" | grep -q '"error"'; then
+  echo "❌ Failed to create matches document:"
+  echo "${MATCH_RESPONSE}"
+  exit 1
+fi
+
+MATCH_ID="$(echo "${MATCH_RESPONSE}" | node -e "
+  let data = '';
+  process.stdin.on('data', (c) => (data += c));
+  process.stdin.on('end', () => {
+    const doc = JSON.parse(data);
+    const name = doc.name || '';
+    console.log(name.split('/').pop() || '');
+  });
+")"
+
+cat <<EOF
+✅ Seeded test chat thread
+   project:    ${PROJECT}
+   email uid:  ${EMAIL_UID}  (obatos2015@gmail.com / simulator)
+   other uid:  ${OTHER_UID}  (+12179044453)
+   chatThread: chatThreads/${THREAD_ID}
+   match:      matches/${MATCH_ID}
+
+Next: open Messages tab on the simulator and confirm the thread appears.
+EOF

--- a/test/features/discovery/data/services/discovery_filtering_test.dart
+++ b/test/features/discovery/data/services/discovery_filtering_test.dart
@@ -64,19 +64,37 @@ void main() {
       );
     });
 
-    test('matchesGenderPreference allows candidate with missing gender', () {
-      final currentUser = UserModel(
-        id: 'current',
-        name: 'Current',
-        showGender: 'female',
-      );
-      final candidate = UserModel(
-        id: 'candidate',
-        name: 'Candidate',
-      );
+    test('matchesLookingForIntent treats blank as compatible', () {
+      final seekerDating = 'Dating';
+      final blank = UserModel(id: '1', name: 'A', lookingFor: '');
+      final missing = UserModel(id: '2', name: 'B');
+      final mixed = UserModel(id: '3', name: 'C', lookingFor: 'Mixed');
+      final friendship =
+          UserModel(id: '4', name: 'D', lookingFor: 'Friendship');
+      final romance = UserModel(id: '5', name: 'E', lookingFor: 'Romance');
 
       expect(
-        DiscoveryFiltering.matchesGenderPreference(candidate, currentUser),
+        DiscoveryFiltering.matchesLookingForIntent(blank, seekerDating),
+        isTrue,
+      );
+      expect(
+        DiscoveryFiltering.matchesLookingForIntent(missing, seekerDating),
+        isTrue,
+      );
+      expect(
+        DiscoveryFiltering.matchesLookingForIntent(mixed, seekerDating),
+        isTrue,
+      );
+      expect(
+        DiscoveryFiltering.matchesLookingForIntent(friendship, seekerDating),
+        isFalse,
+      );
+      expect(
+        DiscoveryFiltering.matchesLookingForIntent(romance, seekerDating),
+        isTrue,
+      );
+      expect(
+        DiscoveryFiltering.matchesLookingForIntent(friendship, 'Mixed'),
         isTrue,
       );
     });

--- a/test/features/discovery/data/services/discovery_filtering_test.dart
+++ b/test/features/discovery/data/services/discovery_filtering_test.dart
@@ -7,7 +7,27 @@ void main() {
     test('normalizeGender maps common aliases', () {
       expect(DiscoveryFiltering.normalizeGender('Male'), 'male');
       expect(DiscoveryFiltering.normalizeGender('woman'), 'female');
+      expect(DiscoveryFiltering.normalizeGender('men'), 'male');
+      expect(DiscoveryFiltering.normalizeGender('women'), 'female');
       expect(DiscoveryFiltering.normalizeGender('both'), 'everyone');
+    });
+
+    test('matchesGenderPreference maps plural showGender preferences', () {
+      final currentUser = UserModel(
+        id: 'current',
+        name: 'Current',
+        showGender: 'women',
+      );
+      final candidate = UserModel(
+        id: 'candidate',
+        name: 'Candidate',
+        userGender: 'female',
+      );
+
+      expect(
+        DiscoveryFiltering.matchesGenderPreference(candidate, currentUser),
+        isTrue,
+      );
     });
 
     test('matchesGenderPreference allows everyone preference', () {

--- a/test/messages/participant_profile_resolver_test.dart
+++ b/test/messages/participant_profile_resolver_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naijasingles/features/messages/services/participant_profile_resolver.dart';
+
+void main() {
+  group('ParticipantProfileResolver field readers', () {
+    test('reads name from name or UserName', () {
+      expect(
+        ParticipantProfileResolver.readNameForTest({'name': '  Obatos  '}),
+        'Obatos',
+      );
+      expect(
+        ParticipantProfileResolver.readNameForTest({'UserName': 'Wizkid'}),
+        'Wizkid',
+      );
+      expect(
+        ParticipantProfileResolver.readNameForTest({'displayName': 'Ada'}),
+        'Ada',
+      );
+      expect(
+        ParticipantProfileResolver.readNameForTest({'name': ''}),
+        isNull,
+      );
+      expect(
+        ParticipantProfileResolver.readNameForTest({'name': 'Phone User'}),
+        isNull,
+      );
+    });
+
+    test('treats placeholder labels as empty', () {
+      expect(ParticipantProfileResolver.isPlaceholderName('Phone User'), isTrue);
+      expect(ParticipantProfileResolver.isPlaceholderName('User'), isTrue);
+      expect(ParticipantProfileResolver.isPlaceholderName('Obatos'), isFalse);
+    });
+
+    test('reads first photo from photos or Pictures', () {
+      expect(
+        ParticipantProfileResolver.readFirstPhotoForTest({
+          'photos': <String>['https://cdn.example/a.jpg'],
+        }),
+        'https://cdn.example/a.jpg',
+      );
+      expect(
+        ParticipantProfileResolver.readFirstPhotoForTest({
+          'Pictures': <String>['https://cdn.example/b.jpg'],
+        }),
+        'https://cdn.example/b.jpg',
+      );
+      expect(
+        ParticipantProfileResolver.readFirstPhotoForTest({'photos': <String>[]}),
+        isNull,
+      );
+    });
+  });
+}

--- a/test/messages/participant_profile_resolver_test.dart
+++ b/test/messages/participant_profile_resolver_test.dart
@@ -1,3 +1,4 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:naijasingles/features/messages/services/participant_profile_resolver.dart';
 
@@ -48,6 +49,62 @@ void main() {
       expect(
         ParticipantProfileResolver.readFirstPhotoForTest({'photos': <String>[]}),
         isNull,
+      );
+    });
+  });
+
+  group('ParticipantProfileResolver.ensureMatchMirrors', () {
+    test('does not write mirrors without a top-level match', () async {
+      final FakeFirebaseFirestore firestore = FakeFirebaseFirestore();
+      final ParticipantProfileResolver resolver =
+          ParticipantProfileResolver(firestore: firestore);
+
+      await resolver.ensureMatchMirrors(
+        currentUserId: 'a',
+        otherUserId: 'b',
+      );
+
+      final snap = await firestore
+          .collection('users')
+          .doc('a')
+          .collection('Matches')
+          .doc('b')
+          .get();
+      expect(snap.exists, isFalse);
+    });
+
+    test('writes mirrors when modern matches doc exists', () async {
+      final FakeFirebaseFirestore firestore = FakeFirebaseFirestore();
+      await firestore.collection('matches').doc('m1').set({
+        'users': <String>['a', 'b'],
+      });
+      final ParticipantProfileResolver resolver =
+          ParticipantProfileResolver(firestore: firestore);
+
+      await resolver.ensureMatchMirrors(
+        currentUserId: 'a',
+        otherUserId: 'b',
+      );
+
+      expect(
+        (await firestore
+                .collection('users')
+                .doc('a')
+                .collection('Matches')
+                .doc('b')
+                .get())
+            .exists,
+        isTrue,
+      );
+      expect(
+        (await firestore
+                .collection('users')
+                .doc('b')
+                .collection('Matches')
+                .doc('a')
+                .get())
+            .exists,
+        isTrue,
       );
     });
   });

--- a/test/messages/participant_profile_resolver_test.dart
+++ b/test/messages/participant_profile_resolver_test.dart
@@ -28,7 +28,8 @@ void main() {
     });
 
     test('treats placeholder labels as empty', () {
-      expect(ParticipantProfileResolver.isPlaceholderName('Phone User'), isTrue);
+      expect(
+          ParticipantProfileResolver.isPlaceholderName('Phone User'), isTrue);
       expect(ParticipantProfileResolver.isPlaceholderName('User'), isTrue);
       expect(ParticipantProfileResolver.isPlaceholderName('Obatos'), isFalse);
     });
@@ -47,7 +48,8 @@ void main() {
         'https://cdn.example/b.jpg',
       );
       expect(
-        ParticipantProfileResolver.readFirstPhotoForTest({'photos': <String>[]}),
+        ParticipantProfileResolver.readFirstPhotoForTest(
+            {'photos': <String>[]}),
         isNull,
       );
     });


### PR DESCRIPTION
## Summary
- Fix chat thread jumping while typing; resolve participant display names/avatars (including seeded “Phone User” threads)
- Soften discovery intent matching so blank/`Mixed`/synonym lookingFor values don’t empty the deck; improve filter Apply confirmation and empty-state copy
- Prevent subscription paywall red-screen by providing IAP blocs when missing (location upsell path)
- Minor profile detail card background polish

## Test plan
- [ ] Open a chat and type — list should not jump on each keystroke
- [ ] Messages list shows real names/avatars after hot restart
- [ ] Discovery Filters: Apply shows in-button “Applied ✓”; set Looking for to All of the Above and confirm Connect returns nearby users
- [ ] Free user: Discovery Filters → Change location → Yes → paywall loads without Provider red screen
- [ ] `flutter test test/features/discovery/data/services/discovery_filtering_test.dart`
- [ ] `flutter test test/messages/participant_profile_resolver_test.dart`


Made with [Cursor](https://cursor.com)