### PR TITLE
fix: batch match lookups and broaden intent Firestore queries

### DIFF
--- a/lib/features/discovery/data/services/discovery_filtering.dart
+++ b/lib/features/discovery/data/services/discovery_filtering.dart
@@ -9,6 +9,29 @@ class DiscoveryFiltering {
     'networking': {'networking', 'business', 'professional'},
   };
 
+  /// Firestore `lookingFor` whereIn values for [intentFilter], including
+  /// title-cased synonyms and `Mixed`. Empty when no query filter should apply.
+  ///
+  /// Firestore whereIn is limited to 10 values; synonym sets stay under that.
+  static List<String> lookingForQueryValues(String? intentFilter) {
+    final String raw = (intentFilter ?? '').trim();
+    if (raw.isEmpty) return const <String>[];
+    final String seeker = raw.toLowerCase();
+    if (seeker == 'mixed') return const <String>[];
+
+    final Set<String> synonyms = _intentSynonyms[seeker] ?? <String>{seeker};
+    final Set<String> values = <String>{'Mixed', raw};
+    for (final String synonym in synonyms) {
+      values.add(_titleCaseIntent(synonym));
+    }
+    return values.toList(growable: false);
+  }
+
+  static String _titleCaseIntent(String value) {
+    if (value.isEmpty) return value;
+    return '${value[0].toUpperCase()}${value.substring(1)}';
+  }
+
   /// Whether [candidate] should appear for the seeker's [intentFilter].
   ///
   /// Missing/blank/`Mixed` intents are treated as compatible so incomplete

--- a/lib/features/discovery/data/services/discovery_service.dart
+++ b/lib/features/discovery/data/services/discovery_service.dart
@@ -542,14 +542,16 @@ class DiscoveryService {
     // 'Mixed' means "All of the Above" — these users should appear in every
     // mode, and a 'Mixed' current-user should see everyone.
     if (intentFilter != null && intentFilter.isNotEmpty) {
-      if (intentFilter == 'Mixed') {
+      final List<String> intentValues =
+          DiscoveryFiltering.lookingForQueryValues(intentFilter);
+      if (intentValues.isEmpty) {
         AppLogger.debug('Intent is Mixed — showing all intents');
       } else {
         query = query.where(
           'lookingFor',
-          whereIn: [intentFilter, 'Mixed'],
+          whereIn: intentValues,
         );
-        AppLogger.debug('Filtering by intent: $intentFilter + Mixed');
+        AppLogger.debug('Filtering by intent whereIn: $intentValues');
       }
     }
 

--- a/lib/features/messages/services/chat_service.dart
+++ b/lib/features/messages/services/chat_service.dart
@@ -748,6 +748,8 @@ class ChatService {
 
         final ParticipantProfileResolver resolver =
             ParticipantProfileResolver(firestore: _firestore);
+        final Set<String> matchedPeerIds =
+            await resolver.loadMatchedPeerIds(userId);
 
         final List<MessageThreadInfo> enriched = await Future.wait(
           threads.map((thread) async {
@@ -755,6 +757,7 @@ class ChatService {
               await resolver.ensureMatchMirrors(
                 currentUserId: userId,
                 otherUserId: thread.otherUserId,
+                matchedPeerIds: matchedPeerIds,
               );
 
               final ParticipantDisplayInfo display = await resolver.resolve(

--- a/lib/features/messages/services/participant_profile_resolver.dart
+++ b/lib/features/messages/services/participant_profile_resolver.dart
@@ -86,9 +86,13 @@ class ParticipantProfileResolver {
   /// Only writes after proving a top-level `matches` / legacy `Matches`
   /// document exists for the pair — never invents match state from a chat
   /// thread alone (seeded/forged threads must not gain profile-read access).
+  ///
+  /// Pass [matchedPeerIds] from [loadMatchedPeerIds] when enriching many
+  /// threads so each call is an O(1) set lookup instead of a full match scan.
   Future<void> ensureMatchMirrors({
     required String currentUserId,
     required String otherUserId,
+    Set<String>? matchedPeerIds,
   }) async {
     if (currentUserId.isEmpty ||
         otherUserId.isEmpty ||
@@ -97,11 +101,6 @@ class ParticipantProfileResolver {
     }
 
     try {
-      final bool matched = await _hasTopLevelMatch(currentUserId, otherUserId);
-      if (!matched) {
-        return;
-      }
-
       final DocumentReference<Map<String, dynamic>> mine = _firestore
           .collection('users')
           .doc(currentUserId)
@@ -113,23 +112,31 @@ class ParticipantProfileResolver {
           .collection('Matches')
           .doc(currentUserId);
 
-      final List<DocumentSnapshot<Map<String, dynamic>>> snaps =
-          await Future.wait(<Future<DocumentSnapshot<Map<String, dynamic>>>>[
-        mine.get(),
-        theirs.get(),
-      ]);
+      // Fast path: local mirror already unlocks profile reads for this user.
+      final DocumentSnapshot<Map<String, dynamic>> mineSnap = await mine.get();
+      if (mineSnap.exists) {
+        return;
+      }
+
+      final bool matched = matchedPeerIds != null
+          ? matchedPeerIds.contains(otherUserId)
+          : await _hasTopLevelMatch(currentUserId, otherUserId);
+      if (!matched) {
+        return;
+      }
+
+      final DocumentSnapshot<Map<String, dynamic>> theirsSnap =
+          await theirs.get();
 
       final List<Future<void>> writes = <Future<void>>[];
-      if (!snaps[0].exists) {
-        writes.add(
-          mine.set(<String, Object?>{
-            'Matches': otherUserId,
-            'userId': otherUserId,
-            'timestamp': FieldValue.serverTimestamp(),
-          }),
-        );
-      }
-      if (!snaps[1].exists) {
+      writes.add(
+        mine.set(<String, Object?>{
+          'Matches': otherUserId,
+          'userId': otherUserId,
+          'timestamp': FieldValue.serverTimestamp(),
+        }),
+      );
+      if (!theirsSnap.exists) {
         writes.add(
           theirs.set(<String, Object?>{
             'Matches': currentUserId,
@@ -138,46 +145,69 @@ class ParticipantProfileResolver {
           }),
         );
       }
-      if (writes.isNotEmpty) {
-        await Future.wait(writes);
-      }
+      await Future.wait(writes);
     } on FirebaseException catch (_) {
       // Best-effort; profile resolve will fall back to thread cache.
     }
   }
 
+  /// Loads peer user IDs from top-level `matches` / `Matches` once per snapshot.
+  Future<Set<String>> loadMatchedPeerIds(String currentUserId) async {
+    if (currentUserId.isEmpty) {
+      return <String>{};
+    }
+
+    final Set<String> peers = <String>{};
+    try {
+      final QuerySnapshot<Map<String, dynamic>> modern = await _firestore
+          .collection('matches')
+          .where('users', arrayContains: currentUserId)
+          .get();
+      for (final QueryDocumentSnapshot<Map<String, dynamic>> doc
+          in modern.docs) {
+        final List<String> users =
+            List<String>.from(doc.data()['users'] as List? ?? const <String>[]);
+        for (final String id in users) {
+          if (id.isNotEmpty && id != currentUserId) {
+            peers.add(id);
+          }
+        }
+      }
+
+      final QuerySnapshot<Map<String, dynamic>> legacy = await _firestore
+          .collection('Matches')
+          .where('users', arrayContains: currentUserId)
+          .get();
+      for (final QueryDocumentSnapshot<Map<String, dynamic>> doc
+          in legacy.docs) {
+        final Map<String, dynamic> data = doc.data();
+        final List<String> users =
+            List<String>.from(data['users'] as List? ?? const <String>[]);
+        for (final String id in users) {
+          if (id.isNotEmpty && id != currentUserId) {
+            peers.add(id);
+          }
+        }
+        final Object? user1 = data['user1'];
+        final Object? user2 = data['user2'];
+        if (user1 == currentUserId && user2 is String && user2.isNotEmpty) {
+          peers.add(user2);
+        } else if (user2 == currentUserId &&
+            user1 is String &&
+            user1.isNotEmpty) {
+          peers.add(user1);
+        }
+      }
+    } on FirebaseException catch (_) {
+      return peers;
+    }
+    return peers;
+  }
+
   /// True when [userId1] and [userId2] appear together in top-level match docs.
   Future<bool> _hasTopLevelMatch(String userId1, String userId2) async {
-    final QuerySnapshot<Map<String, dynamic>> modern = await _firestore
-        .collection('matches')
-        .where('users', arrayContains: userId1)
-        .get();
-    for (final QueryDocumentSnapshot<Map<String, dynamic>> doc in modern.docs) {
-      final List<String> users =
-          List<String>.from(doc.data()['users'] as List? ?? const <String>[]);
-      if (users.contains(userId2)) {
-        return true;
-      }
-    }
-
-    final QuerySnapshot<Map<String, dynamic>> legacy = await _firestore
-        .collection('Matches')
-        .where('users', arrayContains: userId1)
-        .get();
-    for (final QueryDocumentSnapshot<Map<String, dynamic>> doc in legacy.docs) {
-      final Map<String, dynamic> data = doc.data();
-      final List<String> users =
-          List<String>.from(data['users'] as List? ?? const <String>[]);
-      if (users.contains(userId2)) {
-        return true;
-      }
-      if ((data['user1'] == userId1 && data['user2'] == userId2) ||
-          (data['user1'] == userId2 && data['user2'] == userId1)) {
-        return true;
-      }
-    }
-
-    return false;
+    final Set<String> peers = await loadMatchedPeerIds(userId1);
+    return peers.contains(userId2);
   }
 
   /// Updates denormalized thread fields when live values differ from cache.

--- a/lib/features/messages/services/participant_profile_resolver.dart
+++ b/lib/features/messages/services/participant_profile_resolver.dart
@@ -112,9 +112,27 @@ class ParticipantProfileResolver {
           .collection('Matches')
           .doc(currentUserId);
 
-      // Fast path: local mirror already unlocks profile reads for this user.
-      final DocumentSnapshot<Map<String, dynamic>> mineSnap = await mine.get();
-      if (mineSnap.exists) {
+      final List<DocumentSnapshot<Map<String, dynamic>>> snaps =
+          await Future.wait(<Future<DocumentSnapshot<Map<String, dynamic>>>>[
+        mine.get(),
+        theirs.get(),
+      ]);
+      final DocumentSnapshot<Map<String, dynamic>> mineSnap = snaps[0];
+      final DocumentSnapshot<Map<String, dynamic>> theirsSnap = snaps[1];
+
+      // Both mirrors present — nothing to do (no top-level scan).
+      if (mineSnap.exists && theirsSnap.exists) {
+        return;
+      }
+
+      // One-sided local mirror: repair the opposite without re-scanning matches.
+      // Local mirror implies a prior verified write or match creation path.
+      if (mineSnap.exists && !theirsSnap.exists) {
+        await theirs.set(<String, Object?>{
+          'Matches': currentUserId,
+          'userId': currentUserId,
+          'timestamp': FieldValue.serverTimestamp(),
+        });
         return;
       }
 
@@ -125,17 +143,16 @@ class ParticipantProfileResolver {
         return;
       }
 
-      final DocumentSnapshot<Map<String, dynamic>> theirsSnap =
-          await theirs.get();
-
       final List<Future<void>> writes = <Future<void>>[];
-      writes.add(
-        mine.set(<String, Object?>{
-          'Matches': otherUserId,
-          'userId': otherUserId,
-          'timestamp': FieldValue.serverTimestamp(),
-        }),
-      );
+      if (!mineSnap.exists) {
+        writes.add(
+          mine.set(<String, Object?>{
+            'Matches': otherUserId,
+            'userId': otherUserId,
+            'timestamp': FieldValue.serverTimestamp(),
+          }),
+        );
+      }
       if (!theirsSnap.exists) {
         writes.add(
           theirs.set(<String, Object?>{
@@ -145,7 +162,9 @@ class ParticipantProfileResolver {
           }),
         );
       }
-      await Future.wait(writes);
+      if (writes.isNotEmpty) {
+        await Future.wait(writes);
+      }
     } on FirebaseException catch (_) {
       // Best-effort; profile resolve will fall back to thread cache.
     }

--- a/test/features/discovery/data/services/discovery_filtering_test.dart
+++ b/test/features/discovery/data/services/discovery_filtering_test.dart
@@ -118,5 +118,21 @@ void main() {
         isTrue,
       );
     });
+
+    test('lookingForQueryValues includes synonyms and Mixed', () {
+      final dating = DiscoveryFiltering.lookingForQueryValues('Dating');
+      expect(dating, containsAll(<String>['Dating', 'Mixed', 'Romance']));
+      expect(dating, isNot(contains('Social')));
+      expect(dating.length, lessThanOrEqualTo(10));
+
+      final networking = DiscoveryFiltering.lookingForQueryValues('Networking');
+      expect(
+        networking,
+        containsAll(<String>['Networking', 'Mixed', 'Professional']),
+      );
+
+      expect(DiscoveryFiltering.lookingForQueryValues('Mixed'), isEmpty);
+      expect(DiscoveryFiltering.lookingForQueryValues(null), isEmpty);
+    });
   });
 }

--- a/test/messages/participant_profile_resolver_test.dart
+++ b/test/messages/participant_profile_resolver_test.dart
@@ -109,5 +109,80 @@ void main() {
         isTrue,
       );
     });
+
+    test('uses preloaded matchedPeerIds without rewriting for non-peers',
+        () async {
+      final FakeFirebaseFirestore firestore = FakeFirebaseFirestore();
+      await firestore.collection('matches').doc('m1').set({
+        'users': <String>['a', 'b'],
+      });
+      final ParticipantProfileResolver resolver =
+          ParticipantProfileResolver(firestore: firestore);
+
+      final Set<String> peers = await resolver.loadMatchedPeerIds('a');
+      expect(peers, contains('b'));
+
+      await resolver.ensureMatchMirrors(
+        currentUserId: 'a',
+        otherUserId: 'forged',
+        matchedPeerIds: peers,
+      );
+      expect(
+        (await firestore
+                .collection('users')
+                .doc('a')
+                .collection('Matches')
+                .doc('forged')
+                .get())
+            .exists,
+        isFalse,
+      );
+
+      await resolver.ensureMatchMirrors(
+        currentUserId: 'a',
+        otherUserId: 'b',
+        matchedPeerIds: peers,
+      );
+      expect(
+        (await firestore
+                .collection('users')
+                .doc('a')
+                .collection('Matches')
+                .doc('b')
+                .get())
+            .exists,
+        isTrue,
+      );
+    });
+
+    test('skips match scan when local mirror already exists', () async {
+      final FakeFirebaseFirestore firestore = FakeFirebaseFirestore();
+      await firestore
+          .collection('users')
+          .doc('a')
+          .collection('Matches')
+          .doc('b')
+          .set({'Matches': 'b'});
+      final ParticipantProfileResolver resolver =
+          ParticipantProfileResolver(firestore: firestore);
+
+      await resolver.ensureMatchMirrors(
+        currentUserId: 'a',
+        otherUserId: 'b',
+        matchedPeerIds: <String>{},
+      );
+
+      // No top-level match and empty peer set — would fail without fast path.
+      expect(
+        (await firestore
+                .collection('users')
+                .doc('a')
+                .collection('Matches')
+                .doc('b')
+                .get())
+            .exists,
+        isTrue,
+      );
+    });
   });
 }

--- a/test/messages/participant_profile_resolver_test.dart
+++ b/test/messages/participant_profile_resolver_test.dart
@@ -155,7 +155,42 @@ void main() {
       );
     });
 
-    test('skips match scan when local mirror already exists', () async {
+    test('skips match scan when both mirrors already exist', () async {
+      final FakeFirebaseFirestore firestore = FakeFirebaseFirestore();
+      await firestore
+          .collection('users')
+          .doc('a')
+          .collection('Matches')
+          .doc('b')
+          .set({'Matches': 'b'});
+      await firestore
+          .collection('users')
+          .doc('b')
+          .collection('Matches')
+          .doc('a')
+          .set({'Matches': 'a'});
+      final ParticipantProfileResolver resolver =
+          ParticipantProfileResolver(firestore: firestore);
+
+      await resolver.ensureMatchMirrors(
+        currentUserId: 'a',
+        otherUserId: 'b',
+        matchedPeerIds: <String>{},
+      );
+
+      expect(
+        (await firestore
+                .collection('users')
+                .doc('a')
+                .collection('Matches')
+                .doc('b')
+                .get())
+            .exists,
+        isTrue,
+      );
+    });
+
+    test('repairs missing opposite mirror when local mirror exists', () async {
       final FakeFirebaseFirestore firestore = FakeFirebaseFirestore();
       await firestore
           .collection('users')
@@ -172,13 +207,12 @@ void main() {
         matchedPeerIds: <String>{},
       );
 
-      // No top-level match and empty peer set — would fail without fast path.
       expect(
         (await firestore
                 .collection('users')
-                .doc('a')
-                .collection('Matches')
                 .doc('b')
+                .collection('Matches')
+                .doc('a')
                 .get())
             .exists,
         isTrue,


### PR DESCRIPTION
## Summary
- Messages: load matched peer IDs once per chat-list snapshot; reuse for `ensureMatchMirrors`, and short-circuit when a local `Matches` mirror already exists
- Discovery: Firestore `lookingFor` whereIn now includes synonym values (`Romance`, `Professional`, etc.) so unified discovery matches `matchesLookingForIntent`

Addresses Codex P2 comments on #198.

## Test plan
- [ ] Open Messages with several threads — profiles still resolve; no regression in names/avatars
- [ ] Discovery with Networking / Dating still returns profiles; synonym-tagged profiles appear when present
- [ ] `flutter test test/messages/participant_profile_resolver_test.dart`
- [ ] `flutter test test/features/discovery/data/services/discovery_filtering_test.dart`


Made with [Cursor](https://cursor.com)