### PR TITLE
fix: stop chat shake on type/send and theme discovery filters

### DIFF
--- a/lib/features/chat_shared/ui/widgets/chat_composer.dart
+++ b/lib/features/chat_shared/ui/widgets/chat_composer.dart
@@ -55,6 +55,9 @@ class ChatComposer extends StatelessWidget {
         ],
       ),
       child: SafeArea(
+        top: false,
+        left: false,
+        right: false,
         child: Row(
           children: [
             if (showAttachButton)
@@ -75,6 +78,7 @@ class ChatComposer extends StatelessWidget {
                 constraints: BoxConstraints(maxHeight: maxLines * 24.0),
                 child: TextField(
                   controller: controller,
+                  scrollPadding: EdgeInsets.zero,
                   decoration: InputDecoration(
                     hintText: hintText,
                     hintStyle: GoogleFonts.montserrat(
@@ -92,10 +96,12 @@ class ChatComposer extends StatelessWidget {
                       horizontal: 16,
                       vertical: 12,
                     ),
+                    isDense: true,
                   ),
                   style: GoogleFonts.montserrat(
                     fontSize: 14,
                     color: Colors.black87,
+                    height: 1.35,
                   ),
                   maxLines: maxLines,
                   minLines: 1,

--- a/lib/features/discovery/presentation/screens/discovery_preferences_screen.dart
+++ b/lib/features/discovery/presentation/screens/discovery_preferences_screen.dart
@@ -236,284 +236,301 @@ class _DiscoveryPreferencesScreenState
 
   @override
   Widget build(BuildContext context) {
-    return BlocListener<UserfilterBloc, UserfilterState>(
-      listener: (BuildContext context, UserfilterState state) {
-        if (state is UserFilterUpdationFailed) {
-          CustomSnackbar.showSnackBarSimple(
-            'Filter not applied..'.tr(),
-            context,
-          );
-        } else if (state is UserFilterUpdated) {
-          unawaited(HapticFeedback.lightImpact());
-          changeValues.clear();
-          _appliedConfirmTimer?.cancel();
-          setState(() {
-            _strictAge = false;
-            _strictDistance = false;
-            _strictIntent = false;
-            _verifiedOnly = false;
-            _showAppliedConfirm = true;
-          });
-          _appliedConfirmTimer = Timer(const Duration(milliseconds: 1600), () {
-            if (mounted) {
-              setState(() => _showAppliedConfirm = false);
-            }
-          });
-        }
-      },
-      child: PopScope(
-        canPop: false,
-        onPopInvokedWithResult: (bool didPop, Object? result) async {
-          if (didPop) return;
-          final bool allow = await _onWillPop();
-          if (allow && context.mounted) {
-            Navigator.of(context).pop();
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme scheme = theme.colorScheme;
+    final bool isDark = theme.brightness == Brightness.dark;
+    final Color pageBackground =
+        isDark ? scheme.surface : AppColors.backgroundColor;
+    final Color onPage = scheme.onSurface;
+    final ThemeData scopedTheme = theme.copyWith(
+      cardTheme: theme.cardTheme.copyWith(
+        color: isDark ? scheme.surfaceContainerHighest : AppColors.cardColor,
+        surfaceTintColor: Colors.transparent,
+      ),
+    );
+
+    return Theme(
+      data: scopedTheme,
+      child: BlocListener<UserfilterBloc, UserfilterState>(
+        listener: (BuildContext context, UserfilterState state) {
+          if (state is UserFilterUpdationFailed) {
+            CustomSnackbar.showSnackBarSimple(
+              'Filter not applied..'.tr(),
+              context,
+            );
+          } else if (state is UserFilterUpdated) {
+            unawaited(HapticFeedback.lightImpact());
+            changeValues.clear();
+            _appliedConfirmTimer?.cancel();
+            setState(() {
+              _strictAge = false;
+              _strictDistance = false;
+              _strictIntent = false;
+              _verifiedOnly = false;
+              _showAppliedConfirm = true;
+            });
+            _appliedConfirmTimer =
+                Timer(const Duration(milliseconds: 1600), () {
+              if (mounted) {
+                setState(() => _showAppliedConfirm = false);
+              }
+            });
           }
         },
-        child: Scaffold(
-          backgroundColor: AppColors.backgroundColor,
-          appBar: AppBar(
-            elevation: 0,
-            backgroundColor: AppColors.backgroundColor,
-            foregroundColor: AppColors.textPrimary,
-            title: Text(
-              'Discovery Filters'.tr(),
-              style: GoogleFonts.montserrat(
-                fontWeight: FontWeight.w600,
-                fontSize: 18,
+        child: PopScope(
+          canPop: false,
+          onPopInvokedWithResult: (bool didPop, Object? result) async {
+            if (didPop) return;
+            final bool allow = await _onWillPop();
+            if (allow && context.mounted) {
+              Navigator.of(context).pop();
+            }
+          },
+          child: Scaffold(
+            backgroundColor: pageBackground,
+            appBar: AppBar(
+              elevation: 0,
+              backgroundColor: pageBackground,
+              foregroundColor: onPage,
+              title: Text(
+                'Discovery Filters'.tr(),
+                style: GoogleFonts.montserrat(
+                  fontWeight: FontWeight.w600,
+                  fontSize: 18,
+                  color: onPage,
+                ),
               ),
+              actions: [
+                TextButton(
+                  onPressed: _resetFilters,
+                  child: Text(
+                    'Reset filters'.tr(),
+                    style: GoogleFonts.montserrat(
+                      color: isDark
+                          ? AppColors.primaryGreenLight
+                          : AppColors.primaryGreen,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
             ),
-            actions: [
-              TextButton(
-                onPressed: _resetFilters,
-                child: Text(
-                  'Reset filters'.tr(),
-                  style: GoogleFonts.montserrat(
-                    color: AppColors.primaryGreen,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-              ),
-            ],
-          ),
-          body: Column(
-            children: [
-              Expanded(
-                child: ListView(
-                  padding: const EdgeInsets.fromLTRB(
-                    AppSpacing.lg,
-                    AppSpacing.sm,
-                    AppSpacing.lg,
-                    AppSpacing.md,
-                  ),
-                  children: [
-                    Text(
-                      'Discovery'.tr(),
-                      style: GoogleFonts.montserrat(
-                        fontSize: 13,
-                        fontWeight: FontWeight.w600,
-                        color: Theme.of(context).brightness == Brightness.dark
-                            ? Theme.of(context)
-                                .colorScheme
-                                .onSurface
-                                .withValues(alpha: 0.78)
-                            : const Color(0xFF505050),
-                      ),
+            body: Column(
+              children: [
+                Expanded(
+                  child: ListView(
+                    padding: const EdgeInsets.fromLTRB(
+                      AppSpacing.lg,
+                      AppSpacing.sm,
+                      AppSpacing.lg,
+                      AppSpacing.md,
                     ),
-                    const SizedBox(height: 6),
-                    UpdateAddressWidget(
-                      currentUser: widget.currentUser,
-                      hasSubscription: widget.isPurchased,
-                      items: widget.items,
-                      compact: true,
-                    ),
-                    const SizedBox(height: 2),
-                    Text(
-                      'Change your location to see members in other cities.'
-                          .tr(),
-                      style: _helperLineStyle(context),
-                    ),
-                    const SizedBox(height: 10),
-                    ShowmeWidget(
-                      currentUser: widget.currentUser,
-                      changeValues: changeValues,
-                      compact: true,
-                      onEdited: () => setState(() {}),
-                    ),
-                    const SizedBox(height: 8),
-                    LookingForConnectionCard(
-                      key: ValueKey<int>(_lookingForCardKey),
-                      currentUser: widget.currentUser,
-                      changeValues: changeValues,
-                      compact: true,
-                    ),
-                    const SizedBox(height: 8),
-                    DistanceWidget(
-                      currentUser: widget.currentUser,
-                      changeValues: changeValues,
-                      max: widget.isPurchased
-                          ? paidR.toDouble()
-                          : freeR.toDouble(),
-                      compact: true,
-                      onEdited: () => setState(() {}),
-                    ),
-                    const SizedBox(height: 2),
-                    Text(
-                      '${'Showing people within'.tr()} '
-                      '${_distanceMilesRounded()} '
-                      '${'mi'.tr()}',
-                      style: _helperLineStyle(context),
-                    ),
-                    const SizedBox(height: 8),
-                    AgeRangeWidget(
-                      currentUser: widget.currentUser,
-                      changeValues: changeValues,
-                      compact: true,
-                      onEdited: () => setState(() {}),
-                    ),
-                    const SizedBox(height: 2),
-                    Text(
-                      '${'Age range'.tr()}: ${_ageSummary()}',
-                      style: _helperLineStyle(context),
-                    ),
-                    const SizedBox(height: 12),
-                    Text(
-                      'Advanced Filters'.tr(),
-                      style: GoogleFonts.montserrat(
-                        fontSize: 13,
-                        fontWeight: FontWeight.w600,
-                        color: AppColors.textSecondary,
-                      ),
-                    ),
-                    const SizedBox(height: 2),
-                    Text(
-                      'When on, these act as dealbreakers.'.tr(),
-                      style: _helperLineStyle(context),
-                    ),
-                    const SizedBox(height: 6),
-                    settingsSwitchTheme(
-                      context: context,
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: <Widget>[
-                          SwitchListTile(
-                            contentPadding:
-                                const EdgeInsets.symmetric(horizontal: 4),
-                            visualDensity: VisualDensity.compact,
-                            title: Text('Strict age'.tr()),
-                            subtitle: Text(
-                              'Only show people strictly in this age band.'
-                                  .tr(),
-                              style: GoogleFonts.montserrat(fontSize: 12),
-                            ),
-                            value: _strictAge,
-                            onChanged: (bool v) =>
-                                setState(() => _strictAge = v),
-                          ),
-                          SwitchListTile(
-                            contentPadding:
-                                const EdgeInsets.symmetric(horizontal: 4),
-                            visualDensity: VisualDensity.compact,
-                            title: Text('Strict distance'.tr()),
-                            subtitle: Text(
-                              'Hide people slightly outside your radius.'.tr(),
-                              style: GoogleFonts.montserrat(fontSize: 12),
-                            ),
-                            value: _strictDistance,
-                            onChanged: (bool v) =>
-                                setState(() => _strictDistance = v),
-                          ),
-                          SwitchListTile(
-                            contentPadding:
-                                const EdgeInsets.symmetric(horizontal: 4),
-                            visualDensity: VisualDensity.compact,
-                            title: Text('Strict intent'.tr()),
-                            subtitle: Text(
-                              'Match my "looking for" mode more strictly.'.tr(),
-                              style: GoogleFonts.montserrat(fontSize: 12),
-                            ),
-                            value: _strictIntent,
-                            onChanged: (bool v) =>
-                                setState(() => _strictIntent = v),
-                          ),
-                          SwitchListTile(
-                            contentPadding:
-                                const EdgeInsets.symmetric(horizontal: 4),
-                            visualDensity: VisualDensity.compact,
-                            title: Text('Show only verified profiles'.tr()),
-                            subtitle: Text(
-                              'When available, hide profiles not yet verified.'
-                                  .tr(),
-                              style: GoogleFonts.montserrat(fontSize: 12),
-                            ),
-                            value: _verifiedOnly,
-                            onChanged: (bool v) =>
-                                setState(() => _verifiedOnly = v),
-                          ),
-                        ],
-                      ),
-                    ),
-                    const SizedBox(height: 88),
-                  ],
-                ),
-              ),
-              Material(
-                elevation: 12,
-                shadowColor: Colors.black26,
-                color: AppColors.backgroundColor,
-                child: SafeArea(
-                  top: false,
-                  minimum: const EdgeInsets.fromLTRB(16, 8, 16, 12),
-                  child: SizedBox(
-                    width: double.infinity,
-                    child: ElevatedButton(
-                      onPressed: _showAppliedConfirm ? null : _applyFilters,
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: _showAppliedConfirm
-                            ? AppColors.primaryGreen.withValues(alpha: 0.85)
-                            : AppColors.primaryGreen,
-                        foregroundColor: Colors.white,
-                        disabledBackgroundColor:
-                            AppColors.primaryGreen.withValues(alpha: 0.85),
-                        disabledForegroundColor: Colors.white,
-                        elevation: 0,
-                        padding: const EdgeInsets.symmetric(vertical: 16),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
+                    children: [
+                      Text(
+                        'Discovery'.tr(),
+                        style: GoogleFonts.montserrat(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          color: onPage.withValues(alpha: isDark ? 0.78 : 0.72),
                         ),
                       ),
-                      child: AnimatedSwitcher(
-                        duration: const Duration(milliseconds: 200),
-                        child: _showAppliedConfirm
-                            ? Row(
-                                key: const ValueKey<String>('applied'),
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                children: [
-                                  const Icon(Icons.check, size: 20),
-                                  const SizedBox(width: 8),
-                                  Text(
-                                    'Applied'.tr(),
-                                    style: GoogleFonts.montserrat(
-                                      fontSize: 16,
-                                      fontWeight: FontWeight.w600,
-                                    ),
-                                  ),
-                                ],
-                              )
-                            : Text(
-                                key: const ValueKey<String>('apply'),
-                                'Apply filters'.tr(),
-                                style: GoogleFonts.montserrat(
-                                  fontSize: 16,
-                                  fontWeight: FontWeight.w600,
-                                ),
+                      const SizedBox(height: 6),
+                      UpdateAddressWidget(
+                        currentUser: widget.currentUser,
+                        hasSubscription: widget.isPurchased,
+                        items: widget.items,
+                        compact: true,
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        'Change your location to see members in other cities.'
+                            .tr(),
+                        style: _helperLineStyle(context),
+                      ),
+                      const SizedBox(height: 10),
+                      ShowmeWidget(
+                        currentUser: widget.currentUser,
+                        changeValues: changeValues,
+                        compact: true,
+                        onEdited: () => setState(() {}),
+                      ),
+                      const SizedBox(height: 8),
+                      LookingForConnectionCard(
+                        key: ValueKey<int>(_lookingForCardKey),
+                        currentUser: widget.currentUser,
+                        changeValues: changeValues,
+                        compact: true,
+                      ),
+                      const SizedBox(height: 8),
+                      DistanceWidget(
+                        currentUser: widget.currentUser,
+                        changeValues: changeValues,
+                        max: widget.isPurchased
+                            ? paidR.toDouble()
+                            : freeR.toDouble(),
+                        compact: true,
+                        onEdited: () => setState(() {}),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        '${'Showing people within'.tr()} '
+                        '${_distanceMilesRounded()} '
+                        '${'mi'.tr()}',
+                        style: _helperLineStyle(context),
+                      ),
+                      const SizedBox(height: 8),
+                      AgeRangeWidget(
+                        currentUser: widget.currentUser,
+                        changeValues: changeValues,
+                        compact: true,
+                        onEdited: () => setState(() {}),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        '${'Age range'.tr()}: ${_ageSummary()}',
+                        style: _helperLineStyle(context),
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        'Advanced Filters'.tr(),
+                        style: GoogleFonts.montserrat(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          color: onPage.withValues(alpha: isDark ? 0.78 : 0.72),
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        'When on, these act as dealbreakers.'.tr(),
+                        style: _helperLineStyle(context),
+                      ),
+                      const SizedBox(height: 6),
+                      settingsSwitchTheme(
+                        context: context,
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: <Widget>[
+                            SwitchListTile(
+                              contentPadding:
+                                  const EdgeInsets.symmetric(horizontal: 4),
+                              visualDensity: VisualDensity.compact,
+                              title: Text('Strict age'.tr()),
+                              subtitle: Text(
+                                'Only show people strictly in this age band.'
+                                    .tr(),
+                                style: GoogleFonts.montserrat(fontSize: 12),
                               ),
+                              value: _strictAge,
+                              onChanged: (bool v) =>
+                                  setState(() => _strictAge = v),
+                            ),
+                            SwitchListTile(
+                              contentPadding:
+                                  const EdgeInsets.symmetric(horizontal: 4),
+                              visualDensity: VisualDensity.compact,
+                              title: Text('Strict distance'.tr()),
+                              subtitle: Text(
+                                'Hide people slightly outside your radius.'
+                                    .tr(),
+                                style: GoogleFonts.montserrat(fontSize: 12),
+                              ),
+                              value: _strictDistance,
+                              onChanged: (bool v) =>
+                                  setState(() => _strictDistance = v),
+                            ),
+                            SwitchListTile(
+                              contentPadding:
+                                  const EdgeInsets.symmetric(horizontal: 4),
+                              visualDensity: VisualDensity.compact,
+                              title: Text('Strict intent'.tr()),
+                              subtitle: Text(
+                                'Match my "looking for" mode more strictly.'
+                                    .tr(),
+                                style: GoogleFonts.montserrat(fontSize: 12),
+                              ),
+                              value: _strictIntent,
+                              onChanged: (bool v) =>
+                                  setState(() => _strictIntent = v),
+                            ),
+                            SwitchListTile(
+                              contentPadding:
+                                  const EdgeInsets.symmetric(horizontal: 4),
+                              visualDensity: VisualDensity.compact,
+                              title: Text('Show only verified profiles'.tr()),
+                              subtitle: Text(
+                                'When available, hide profiles not yet verified.'
+                                    .tr(),
+                                style: GoogleFonts.montserrat(fontSize: 12),
+                              ),
+                              value: _verifiedOnly,
+                              onChanged: (bool v) =>
+                                  setState(() => _verifiedOnly = v),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 88),
+                    ],
+                  ),
+                ),
+                Material(
+                  elevation: 12,
+                  shadowColor: Colors.black26,
+                  color: pageBackground,
+                  child: SafeArea(
+                    top: false,
+                    minimum: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+                    child: SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton(
+                        onPressed: _showAppliedConfirm ? null : _applyFilters,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: _showAppliedConfirm
+                              ? AppColors.primaryGreen.withValues(alpha: 0.85)
+                              : AppColors.primaryGreen,
+                          foregroundColor: Colors.white,
+                          disabledBackgroundColor:
+                              AppColors.primaryGreen.withValues(alpha: 0.85),
+                          disabledForegroundColor: Colors.white,
+                          elevation: 0,
+                          padding: const EdgeInsets.symmetric(vertical: 16),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                        ),
+                        child: AnimatedSwitcher(
+                          duration: const Duration(milliseconds: 200),
+                          child: _showAppliedConfirm
+                              ? Row(
+                                  key: const ValueKey<String>('applied'),
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    const Icon(Icons.check, size: 20),
+                                    const SizedBox(width: 8),
+                                    Text(
+                                      'Applied'.tr(),
+                                      style: GoogleFonts.montserrat(
+                                        fontSize: 16,
+                                        fontWeight: FontWeight.w600,
+                                      ),
+                                    ),
+                                  ],
+                                )
+                              : Text(
+                                  key: const ValueKey<String>('apply'),
+                                  'Apply filters'.tr(),
+                                  style: GoogleFonts.montserrat(
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                        ),
                       ),
                     ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/features/messages/chat_thread_screen.dart
+++ b/lib/features/messages/chat_thread_screen.dart
@@ -49,7 +49,9 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
       ParticipantProfileResolver();
   String? _currentUserId;
   Timer? _typingDebounce;
+  Timer? _typingHeartbeat;
   bool _typingIndicatorActive = false;
+  DateTime? _lastTypingWriteAt;
   bool _showSearch = false;
   String _searchQuery = '';
   String? _replyToMessageId;
@@ -83,6 +85,8 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
     final bool hasText = _messageController.text.trim().isNotEmpty;
     if (!hasText) {
       _typingDebounce?.cancel();
+      _typingHeartbeat?.cancel();
+      _typingHeartbeat = null;
       if (_typingIndicatorActive) {
         _typingIndicatorActive = false;
         unawaited(_chatService.setTyping(widget.threadId, isTyping: false));
@@ -90,16 +94,32 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
       return;
     }
 
-    // One Firestore write when typing starts; refresh the idle timer only.
-    if (!_typingIndicatorActive) {
-      _typingIndicatorActive = true;
-      unawaited(_chatService.setTyping(widget.threadId, isTyping: true));
-    }
+    // Write on start, then heartbeat every 4s so watchers (8s TTL) stay fresh
+    // without a Firestore write on every keystroke.
+    _publishTypingHeartbeat(force: !_typingIndicatorActive);
+    _typingIndicatorActive = true;
+    _typingHeartbeat ??= Timer.periodic(const Duration(seconds: 4), (_) {
+      if (!_typingIndicatorActive) return;
+      _publishTypingHeartbeat(force: true);
+    });
+
     _typingDebounce?.cancel();
     _typingDebounce = Timer(const Duration(seconds: 2), () {
+      _typingHeartbeat?.cancel();
+      _typingHeartbeat = null;
       _typingIndicatorActive = false;
       unawaited(_chatService.setTyping(widget.threadId, isTyping: false));
     });
+  }
+
+  void _publishTypingHeartbeat({required bool force}) {
+    final DateTime now = DateTime.now();
+    final DateTime? last = _lastTypingWriteAt;
+    if (!force && last != null && now.difference(last).inSeconds < 4) {
+      return;
+    }
+    _lastTypingWriteAt = now;
+    unawaited(_chatService.setTyping(widget.threadId, isTyping: true));
   }
 
   Future<void> _resolveParticipantDisplay() async {
@@ -149,6 +169,7 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
   void dispose() {
     _messageController.removeListener(_onComposerTextChanged);
     _typingDebounce?.cancel();
+    _typingHeartbeat?.cancel();
     if (_typingIndicatorActive) {
       unawaited(_chatService.setTyping(widget.threadId, isTyping: false));
     }

--- a/lib/features/messages/chat_thread_screen.dart
+++ b/lib/features/messages/chat_thread_screen.dart
@@ -48,8 +48,8 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
   final ParticipantProfileResolver _participantResolver =
       ParticipantProfileResolver();
   String? _currentUserId;
-  bool _hasText = false;
   Timer? _typingDebounce;
+  bool _typingIndicatorActive = false;
   bool _showSearch = false;
   String _searchQuery = '';
   String? _replyToMessageId;
@@ -66,20 +66,9 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
     _displayName = widget.userName;
     _displayAvatarUrl = widget.avatarUrl;
 
-    // Listen to text changes for send button animation
-    _messageController.addListener(() {
-      final hasText = _messageController.text.trim().isNotEmpty;
-      if (hasText != _hasText) {
-        setState(() {
-          _hasText = hasText;
-        });
-      }
-      _typingDebounce?.cancel();
-      unawaited(_chatService.setTyping(widget.threadId, isTyping: true));
-      _typingDebounce = Timer(const Duration(seconds: 2), () {
-        unawaited(_chatService.setTyping(widget.threadId, isTyping: false));
-      });
-    });
+    // Do not setState here — rebuilding the message list while typing causes
+    // visible shake. Composer watches the controller via ValueListenableBuilder.
+    _messageController.addListener(_onComposerTextChanged);
 
     unawaited(_chatService.markThreadAsRead(widget.threadId));
     unawaited(_resolveParticipantDisplay());
@@ -87,6 +76,29 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
     // Scroll to bottom when messages load
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _scrollToBottom();
+    });
+  }
+
+  void _onComposerTextChanged() {
+    final bool hasText = _messageController.text.trim().isNotEmpty;
+    if (!hasText) {
+      _typingDebounce?.cancel();
+      if (_typingIndicatorActive) {
+        _typingIndicatorActive = false;
+        unawaited(_chatService.setTyping(widget.threadId, isTyping: false));
+      }
+      return;
+    }
+
+    // One Firestore write when typing starts; refresh the idle timer only.
+    if (!_typingIndicatorActive) {
+      _typingIndicatorActive = true;
+      unawaited(_chatService.setTyping(widget.threadId, isTyping: true));
+    }
+    _typingDebounce?.cancel();
+    _typingDebounce = Timer(const Duration(seconds: 2), () {
+      _typingIndicatorActive = false;
+      unawaited(_chatService.setTyping(widget.threadId, isTyping: false));
     });
   }
 
@@ -135,23 +147,45 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
 
   @override
   void dispose() {
+    _messageController.removeListener(_onComposerTextChanged);
     _typingDebounce?.cancel();
-    unawaited(_chatService.setTyping(widget.threadId, isTyping: false));
+    if (_typingIndicatorActive) {
+      unawaited(_chatService.setTyping(widget.threadId, isTyping: false));
+    }
     _messageController.dispose();
     _scrollController.dispose();
     super.dispose();
   }
 
-  void _scrollToBottom() {
-    if (_scrollController.hasClients) {
+  void _scrollToBottom({bool animated = false}) {
+    if (!_scrollController.hasClients) {
+      return;
+    }
+    // reverse: true ListView — visual bottom is offset 0.
+    const double target = 0;
+    final double current = _scrollController.position.pixels;
+    if ((current - target).abs() < 1.0) {
+      return;
+    }
+    if (animated) {
       unawaited(
         _scrollController.animateTo(
-          _scrollController.position.maxScrollExtent,
-          duration: const Duration(milliseconds: 300),
+          target,
+          duration: const Duration(milliseconds: 250),
           curve: Curves.easeOut,
         ),
       );
+    } else {
+      _scrollController.jumpTo(target);
     }
+  }
+
+  /// With [ListView.reverse], offset 0 is the newest messages.
+  bool get _isScrolledUpIntoHistory {
+    if (!_scrollController.hasClients) {
+      return false;
+    }
+    return _scrollController.position.pixels > 80;
   }
 
   Future<void> _pickAndSendImage() async {
@@ -165,9 +199,8 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
         threadId: widget.threadId,
         imagePath: picked.path,
       );
-      if (mounted) {
-        Future.delayed(const Duration(milliseconds: 100), _scrollToBottom);
-      }
+      // StreamBuilder scrolls once the new message arrives — avoid a second
+      // competing animateTo that causes the bounce.
     } on Object catch (error) {
       _showErrorSnackBar('Could not send image: $error');
     }
@@ -194,14 +227,16 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
         replyToMessageId: _replyToMessageId,
       );
       if (success) {
-        setState(() {
-          _replyToMessageId = null;
-          _replyPreview = null;
-        });
-      }
-      if (success) {
         _messageController.clear();
-        Future.delayed(const Duration(milliseconds: 100), _scrollToBottom);
+        // Avoid rebuilding the message list unless the reply bar must close.
+        if (_replyToMessageId != null || _replyPreview != null) {
+          setState(() {
+            _replyToMessageId = null;
+            _replyPreview = null;
+          });
+        }
+        // reverse ListView already shows the new bubble at the bottom —
+        // do not jumpTo(0); that is what shook the screen on send.
       }
     } on Object catch (error) {
       _showErrorSnackBar(error.toString().replaceAll('Exception: ', ''));
@@ -356,90 +391,102 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
             ),
           // Chat messages
           Expanded(
-            child: StreamBuilder<List<Message>>(
-              stream: _chatService.getMessagesStream(widget.threadId),
-              builder: (context, snapshot) {
-                if (snapshot.connectionState == ConnectionState.waiting) {
-                  return const AppLoadingView(message: 'Loading messages...');
-                }
+            child: RepaintBoundary(
+              child: StreamBuilder<List<Message>>(
+                stream: _chatService.getMessagesStream(widget.threadId),
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState == ConnectionState.waiting) {
+                    return const AppLoadingView(message: 'Loading messages...');
+                  }
 
-                if (snapshot.hasError) {
-                  return AppErrorView(
-                    title: 'Unable to load messages',
-                    message: 'Error loading messages',
-                    onRetry: () => setState(() {}),
-                  );
-                }
-
-                var messages = snapshot.data ?? [];
-                if (_searchQuery.isNotEmpty) {
-                  final q = _searchQuery.toLowerCase();
-                  messages = messages
-                      .where((m) => m.text.toLowerCase().contains(q))
-                      .toList();
-                }
-
-                if (messages.isEmpty) {
-                  return AppEmptyView(
-                    title: 'No Messages Yet',
-                    subtitle: 'Say hi to $_displayName!',
-                    icon: Icons.chat_bubble_outline,
-                  );
-                }
-
-                final String? newestId =
-                    messages.isNotEmpty ? messages.last.id : null;
-                final bool shouldScroll =
-                    messages.length != _lastMessageCount ||
-                        newestId != _lastMessageId;
-                if (shouldScroll) {
-                  _lastMessageCount = messages.length;
-                  _lastMessageId = newestId;
-                  WidgetsBinding.instance.addPostFrameCallback((_) {
-                    _scrollToBottom();
-                  });
-                }
-
-                return ListView.builder(
-                  controller: _scrollController,
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
-                  itemCount: messages.length,
-                  itemBuilder: (context, index) {
-                    final message = messages[index];
-                    final isMe = message.senderId == _currentUserId;
-
-                    final showDateSeparator = index == 0 ||
-                        !_isSameDay(
-                          messages[index].timestamp,
-                          messages[index - 1].timestamp,
-                        );
-
-                    final vm = ChatMessageViewModel(
-                      id: message.id,
-                      text: message.text,
-                      timestamp: message.timestamp,
-                      senderId: message.senderId,
-                      isOwnMessage: isMe,
-                      senderAvatarUrl: isMe ? null : _displayAvatarUrl,
-                      isRead: message.isRead,
-                      showReadReceipt: true,
-                      imageUrl: message.imageUrl,
+                  if (snapshot.hasError) {
+                    return AppErrorView(
+                      title: 'Unable to load messages',
+                      message: 'Error loading messages',
+                      onRetry: () => setState(() {}),
                     );
+                  }
 
-                    return Column(
-                      children: [
-                        if (showDateSeparator)
-                          _buildDateSeparator(message.timestamp),
-                        GestureDetector(
-                          onLongPress: () => _showMessageActions(message.id),
-                          child: ChatBubble(message: vm),
-                        ),
-                      ],
+                  var messages = snapshot.data ?? [];
+                  if (_searchQuery.isNotEmpty) {
+                    final q = _searchQuery.toLowerCase();
+                    messages = messages
+                        .where((m) => m.text.toLowerCase().contains(q))
+                        .toList();
+                  }
+
+                  if (messages.isEmpty) {
+                    return AppEmptyView(
+                      title: 'No Messages Yet',
+                      subtitle: 'Say hi to $_displayName!',
+                      icon: Icons.chat_bubble_outline,
                     );
-                  },
-                );
-              },
+                  }
+
+                  final String? newestId =
+                      messages.isNotEmpty ? messages.last.id : null;
+                  final bool shouldScroll =
+                      messages.length != _lastMessageCount ||
+                          newestId != _lastMessageId;
+                  if (shouldScroll) {
+                    _lastMessageCount = messages.length;
+                    _lastMessageId = newestId;
+                    WidgetsBinding.instance.addPostFrameCallback((_) {
+                      if (!mounted) return;
+                      // reverse:true keeps newest at offset 0. Only jump when
+                      // the user scrolled up — jumping while already at the
+                      // bottom causes the post-send shake.
+                      if (_isScrolledUpIntoHistory) {
+                        _scrollToBottom();
+                      }
+                    });
+                  }
+
+                  return ListView.builder(
+                    controller: _scrollController,
+                    reverse: true,
+                    physics: const ClampingScrollPhysics(),
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 16, vertical: 20),
+                    itemCount: messages.length,
+                    itemBuilder: (context, index) {
+                      // reverse: true → index 0 is the newest message.
+                      final int messageIndex = messages.length - 1 - index;
+                      final message = messages[messageIndex];
+                      final isMe = message.senderId == _currentUserId;
+
+                      final showDateSeparator = messageIndex == 0 ||
+                          !_isSameDay(
+                            messages[messageIndex].timestamp,
+                            messages[messageIndex - 1].timestamp,
+                          );
+
+                      final vm = ChatMessageViewModel(
+                        id: message.id,
+                        text: message.text,
+                        timestamp: message.timestamp,
+                        senderId: message.senderId,
+                        isOwnMessage: isMe,
+                        senderAvatarUrl: isMe ? null : _displayAvatarUrl,
+                        isRead: message.isRead,
+                        showReadReceipt: true,
+                        imageUrl: message.imageUrl,
+                      );
+
+                      return Column(
+                        children: [
+                          if (showDateSeparator)
+                            _buildDateSeparator(message.timestamp),
+                          GestureDetector(
+                            onLongPress: () => _showMessageActions(message.id),
+                            child: ChatBubble(message: vm),
+                          ),
+                        ],
+                      );
+                    },
+                  );
+                },
+              ),
             ),
           ),
 
@@ -466,14 +513,20 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
                 ],
               ),
             ),
-          ChatComposer(
-            controller: _messageController,
-            onSend: _sendMessage,
-            hasText: _hasText,
-            showAttachButton: true,
-            onAttachTap: _pickAndSendImage,
-            showEmojiButton: true,
-            onEmojiTap: _showEmojiPicker,
+          ValueListenableBuilder<TextEditingValue>(
+            valueListenable: _messageController,
+            builder: (BuildContext context, TextEditingValue value, _) {
+              final bool hasText = value.text.trim().isNotEmpty;
+              return ChatComposer(
+                controller: _messageController,
+                onSend: _sendMessage,
+                hasText: hasText,
+                showAttachButton: true,
+                onAttachTap: _pickAndSendImage,
+                showEmojiButton: true,
+                onEmojiTap: _showEmojiPicker,
+              );
+            },
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- Fix chat thread shake while typing (no full-list rebuild / no per-keystroke typing writes)
- Fix post-send bounce on reverse message lists (do not `jumpTo(0)` when already at the bottom)
- Fix Discovery Filters night/dark appearance (theme-aware page, AppBar, and card surfaces)

## Test plan
- [ ] Hot restart → open chat → type continuously — list should stay still
- [ ] Send several messages while at the bottom — no bounce/shake
- [ ] Scroll up in history, receive/send a new message — should jump to newest
- [ ] Enable Dark Mode → Discovery Filters — page/title/cards consistent (no white scaffold + dark cards)


Made with [Cursor](https://cursor.com)