### PR TITLE
fix: autoscroll near bottom without jumping at offset zero

### DIFF
--- a/lib/features/messages/chat_thread_screen.dart
+++ b/lib/features/messages/chat_thread_screen.dart
@@ -202,11 +202,12 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
   }
 
   /// With [ListView.reverse], offset 0 is the newest messages.
-  bool get _isScrolledUpIntoHistory {
+  /// True when the user is still "following" the live conversation.
+  bool get _isNearBottom {
     if (!_scrollController.hasClients) {
-      return false;
+      return true;
     }
-    return _scrollController.position.pixels > 80;
+    return _scrollController.position.pixels <= 80;
   }
 
   Future<void> _pickAndSendImage() async {
@@ -454,10 +455,11 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
                     _lastMessageId = newestId;
                     WidgetsBinding.instance.addPostFrameCallback((_) {
                       if (!mounted) return;
-                      // reverse:true keeps newest at offset 0. Only jump when
-                      // the user scrolled up — jumping while already at the
-                      // bottom causes the post-send shake.
-                      if (_isScrolledUpIntoHistory) {
+                      // reverse:true — newest is at offset 0.
+                      // Follow the conversation when near the bottom.
+                      // _scrollToBottom no-ops within 1px of 0 (avoids send shake).
+                      // Deep history (scrolled up) does not auto-jump.
+                      if (_isNearBottom) {
                         _scrollToBottom();
                       }
                     });

--- a/lib/features/messages/chat_thread_screen.dart
+++ b/lib/features/messages/chat_thread_screen.dart
@@ -453,13 +453,14 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
                   if (shouldScroll) {
                     _lastMessageCount = messages.length;
                     _lastMessageId = newestId;
+                    // Capture before the new ListView lays out. After insert,
+                    // reverse-list extent growth can push pixels past 80 even
+                    // when the user was in the follow zone.
+                    final bool followLiveEdge = _isNearBottom;
                     WidgetsBinding.instance.addPostFrameCallback((_) {
                       if (!mounted) return;
-                      // reverse:true — newest is at offset 0.
-                      // Follow the conversation when near the bottom.
                       // _scrollToBottom no-ops within 1px of 0 (avoids send shake).
-                      // Deep history (scrolled up) does not auto-jump.
-                      if (_isNearBottom) {
+                      if (followLiveEdge) {
                         _scrollToBottom();
                       }
                     });


### PR DESCRIPTION
## Summary
- Invert the reverse-list autoscroll guard: pin to newest when **near** the bottom (≤80px)
- Keep `_scrollToBottom` no-op when already at ~offset 0 (avoids post-send shake)
- Do not auto-jump when the user has scrolled into older history

Addresses Codex P2 on #201.

## Test plan
- [ ] At bottom, send a message — no shake; new bubble visible
- [ ] Drag ~20–80px up, send/receive — list advances to show the new bubble
- [ ] Scroll deep into history, new message arrives — stay put until user scrolls


Made with [Cursor](https://cursor.com)