### PR TITLE
fix: premium Continue no-op and chat pin on own send

### DIFF
--- a/lib/common/data/repo/in_app_purchase_repo.dart
+++ b/lib/common/data/repo/in_app_purchase_repo.dart
@@ -1,4 +1,5 @@
 import 'dart:developer';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:in_app_purchase/in_app_purchase.dart';
@@ -7,13 +8,14 @@ import 'package:in_app_purchase_storekit/in_app_purchase_storekit.dart';
 import 'package:in_app_purchase_storekit/store_kit_wrappers.dart';
 
 import '../../../features/home/ui/tab/tabbar.dart';
+import '../../../features/payment/ios_payment_queue_delegate.dart';
 import '../../../features/payment/ui/products.dart';
 import '../../../models/user_model.dart';
 import '../../constants/constants.dart';
 
 abstract class InAppPurchaseRepo {
   Future<List<ProductDetails>> getProductsDetailsById();
-  Future buyConsumable({required ProductDetails productDetails});
+  Future<void> buyConsumable({required ProductDetails productDetails});
 }
 
 class InAppPurchaseRepoImpl extends InAppPurchaseRepo {
@@ -59,12 +61,56 @@ class InAppPurchaseRepoImpl extends InAppPurchaseRepo {
     }
   }
 
+  static bool _iosPaymentQueueDelegateSet = false;
+
+  /// Ensures the iOS payment-queue delegate is registered once per process.
+  static Future<void> ensureIosPaymentQueueDelegate() async {
+    if (!_isIOS || _iosPaymentQueueDelegateSet) return;
+    try {
+      final InAppPurchaseStoreKitPlatformAddition iosAddition =
+          inApp.getPlatformAddition<InAppPurchaseStoreKitPlatformAddition>();
+      await iosAddition.setDelegate(AfropeepPaymentQueueDelegate());
+      _iosPaymentQueueDelegateSet = true;
+    } on Object catch (e) {
+      log('[IAP] Failed to set StoreKit payment queue delegate: $e');
+    }
+  }
+
+  PurchaseParam _purchaseParamFor(ProductDetails productDetails) {
+    if (productDetails is GooglePlayProductDetails) {
+      final String? offerToken = productDetails.offerToken;
+      // Billing 5+ requires an offer token for subscriptions.
+      return GooglePlayPurchaseParam(
+        productDetails: productDetails,
+        offerToken: offerToken,
+      );
+    }
+    return PurchaseParam(productDetails: productDetails);
+  }
+
   @override
-  Future buyConsumable({required ProductDetails productDetails}) async {
-    final PurchaseParam purchaseParam =
-        PurchaseParam(productDetails: productDetails);
-    await inApp.buyNonConsumable(purchaseParam: purchaseParam);
-    log('=============-----------isPurchaseSuccessfully');
+  Future<void> buyConsumable({required ProductDetails productDetails}) async {
+    final bool available = await inApp.isAvailable();
+    if (!available) {
+      throw StateError('Store is not available on this device.');
+    }
+
+    await ensureIosPaymentQueueDelegate();
+
+    final PurchaseParam purchaseParam = _purchaseParamFor(productDetails);
+    log('[IAP] Starting purchase for ${productDetails.id}');
+
+    final bool started = await inApp.buyNonConsumable(
+      purchaseParam: purchaseParam,
+    );
+    if (!started) {
+      // Plugin returns false when another purchase is pending / sheet not shown.
+      throw StateError(
+        'Purchase could not be started. Wait a moment and try again, '
+        'or restore purchases from Account Settings.',
+      );
+    }
+    log('[IAP] Purchase sheet presented for ${productDetails.id}');
   }
 
   /// Fetches store product IDs from `Packages` (platform-specific when set).

--- a/lib/features/messages/chat_thread_screen.dart
+++ b/lib/features/messages/chat_thread_screen.dart
@@ -58,6 +58,9 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
   String? _replyPreview;
   int _lastMessageCount = 0;
   String? _lastMessageId;
+  /// After the user sends, pin to the live edge even if they were reading history
+  /// (Tinder/Hinge-style). Incoming messages still respect [_isNearBottom].
+  bool _pinToBottomAfterOwnSend = false;
   late String _displayName;
   String? _displayAvatarUrl;
 
@@ -221,8 +224,8 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
         threadId: widget.threadId,
         imagePath: picked.path,
       );
-      // StreamBuilder scrolls once the new message arrives — avoid a second
-      // competing animateTo that causes the bounce.
+      // Own send: pin when the new message lands (even if scrolled into history).
+      _pinToBottomAfterOwnSend = true;
     } on Object catch (error) {
       _showErrorSnackBar('Could not send image: $error');
     }
@@ -257,8 +260,9 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
             _replyPreview = null;
           });
         }
-        // reverse ListView already shows the new bubble at the bottom —
-        // do not jumpTo(0); that is what shook the screen on send.
+        // Own send always follows the live edge (even when reading history).
+        // StreamBuilder scrolls once; _scrollToBottom no-ops if already at 0.
+        _pinToBottomAfterOwnSend = true;
       }
     } on Object catch (error) {
       _showErrorSnackBar(error.toString().replaceAll('Exception: ', ''));
@@ -456,7 +460,14 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
                     // Capture before the new ListView lays out. After insert,
                     // reverse-list extent growth can push pixels past 80 even
                     // when the user was in the follow zone.
-                    final bool followLiveEdge = _isNearBottom;
+                    final bool pinAfterOwnSend = _pinToBottomAfterOwnSend;
+                    final bool newestIsOwn = messages.isNotEmpty &&
+                        messages.last.senderId == _currentUserId;
+                    final bool followLiveEdge = _isNearBottom ||
+                        (pinAfterOwnSend && newestIsOwn);
+                    if (pinAfterOwnSend && newestIsOwn) {
+                      _pinToBottomAfterOwnSend = false;
+                    }
                     WidgetsBinding.instance.addPostFrameCallback((_) {
                       if (!mounted) return;
                       // _scrollToBottom no-ops within 1px of 0 (avoids send shake).

--- a/lib/features/payment/iap_user_facing_message.dart
+++ b/lib/features/payment/iap_user_facing_message.dart
@@ -44,6 +44,10 @@ String userFacingPurchaseFromRawString(String raw) {
   if (_rawLooksCanceled(lower)) {
     return 'Purchase canceled. No charge was made.';
   }
+  if (lower.contains('could not be started') ||
+      lower.contains('store is not available')) {
+    return 'Purchase could not be started. Please try again in a moment.';
+  }
   if (lower.contains('platformexception')) {
     return 'Purchase could not be completed. Please try again.';
   }

--- a/lib/features/payment/ios_payment_queue_delegate.dart
+++ b/lib/features/payment/ios_payment_queue_delegate.dart
@@ -1,0 +1,14 @@
+import 'package:in_app_purchase_storekit/store_kit_wrappers.dart';
+
+/// Minimal StoreKit payment-queue delegate (required on iOS 13+ for some flows).
+class AfropeepPaymentQueueDelegate extends SKPaymentQueueDelegateWrapper {
+  @override
+  bool shouldContinueTransaction(
+    SKPaymentTransactionWrapper transaction,
+    SKStorefrontWrapper storefront,
+  ) =>
+      true;
+
+  @override
+  bool shouldShowPriceConsent() => false;
+}

--- a/lib/features/payment/presentation/bloc/subscription_bloc.dart
+++ b/lib/features/payment/presentation/bloc/subscription_bloc.dart
@@ -6,6 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:in_app_purchase/in_app_purchase.dart';
 
 import '../../../../common/bloc/user/user_bloc.dart';
+import '../../../../common/data/repo/in_app_purchase_repo.dart';
 import '../../../../config/app_config.dart';
 import '../../../../services/subscription_iap_analytics.dart';
 import '../../data/subscription_functions_service.dart';
@@ -161,12 +162,16 @@ class SubscriptionBloc extends Bloc<SubscriptionEvent, SubscriptionState> {
     SubscriptionUserChanged event,
     Emitter<SubscriptionState> emit,
   ) async {
-    await _purchaseSub?.cancel();
-    _purchaseSub = null;
-    _uid = event.uid;
-    _processedKeys.clear();
+    final String? nextUid = event.uid;
+    final bool uidChanged = nextUid != _uid;
+    _uid = nextUid;
+    if (uidChanged) {
+      _processedKeys.clear();
+    }
 
-    if (_uid == null) {
+    // Already attached — paywall may re-assert the same uid; do not cancel/rebind
+    // (that can drop in-flight purchase updates).
+    if (_purchaseSub != null) {
       return;
     }
 
@@ -175,6 +180,10 @@ class SubscriptionBloc extends Bloc<SubscriptionEvent, SubscriptionState> {
       return;
     }
 
+    // Official plugin guidance: subscribe to purchaseStream *before* buy/restore.
+    // Previously we only listened when uid was non-null, so Continue could appear
+    // to do nothing if UserBloc lagged behind the user passed into Products.
+    await InAppPurchaseRepoImpl.ensureIosPaymentQueueDelegate();
     _purchaseSub = InAppPurchase.instance.purchaseStream.listen(
       (purchases) => add(SubscriptionPurchaseBatch(purchases)),
       onError: (Object e) =>
@@ -220,7 +229,23 @@ class SubscriptionBloc extends Bloc<SubscriptionEvent, SubscriptionState> {
     Emitter<SubscriptionState> emit,
   ) async {
     final uid = _uid;
-    if (uid == null) return;
+    if (uid == null || uid.isEmpty) {
+      // Do not silently drop store updates — that looks like "Continue did nothing".
+      final bool hasTerminal = event.purchases.any(
+        (p) =>
+            p.status == PurchaseStatus.purchased ||
+            p.status == PurchaseStatus.restored ||
+            p.status == PurchaseStatus.error,
+      );
+      if (hasTerminal) {
+        emit(state.copyWith(
+          purchaseInProgress: false,
+          userMessage:
+              'Please sign in again to finish activating Premium.',
+        ));
+      }
+      return;
+    }
 
     for (final purchase in event.purchases) {
       final key =

--- a/lib/features/payment/presentation/bloc/subscription_bloc.dart
+++ b/lib/features/payment/presentation/bloc/subscription_bloc.dart
@@ -141,6 +141,10 @@ class SubscriptionBloc extends Bloc<SubscriptionEvent, SubscriptionState> {
   StreamSubscription<List<PurchaseDetails>>? _purchaseSub;
   String? _uid;
   final Set<String> _processedKeys = {};
+
+  /// Store updates that arrived before [_uid] was known. Flushed in
+  /// [_onUserChanged] once a non-empty uid is set.
+  final List<PurchaseDetails> _pendingPurchases = [];
   bool _awaitingRestore = false;
   Timer? _restoreTimer;
 
@@ -169,26 +173,29 @@ class SubscriptionBloc extends Bloc<SubscriptionEvent, SubscriptionState> {
       _processedKeys.clear();
     }
 
-    // Already attached — paywall may re-assert the same uid; do not cancel/rebind
+    // Attach once. Paywall may re-assert the same uid; do not cancel/rebind
     // (that can drop in-flight purchase updates).
-    if (_purchaseSub != null) {
-      return;
+    if (_purchaseSub == null) {
+      final available = await InAppPurchase.instance.isAvailable();
+      if (available) {
+        // Official plugin guidance: subscribe to purchaseStream *before*
+        // buy/restore. We may attach before uid is known; batches are buffered.
+        await InAppPurchaseRepoImpl.ensureIosPaymentQueueDelegate();
+        _purchaseSub = InAppPurchase.instance.purchaseStream.listen(
+          (purchases) => add(SubscriptionPurchaseBatch(purchases)),
+          onError: (Object e) =>
+              add(SubscriptionPurchaseStreamFailed(e.toString())),
+        );
+      }
     }
 
-    final available = await InAppPurchase.instance.isAvailable();
-    if (!available) {
-      return;
+    // Reprocess anything that arrived while uid was still loading.
+    if (_uid != null && _uid!.isNotEmpty && _pendingPurchases.isNotEmpty) {
+      final List<PurchaseDetails> pending =
+          List<PurchaseDetails>.from(_pendingPurchases);
+      _pendingPurchases.clear();
+      await _processPurchaseBatch(pending, emit);
     }
-
-    // Official plugin guidance: subscribe to purchaseStream *before* buy/restore.
-    // Previously we only listened when uid was non-null, so Continue could appear
-    // to do nothing if UserBloc lagged behind the user passed into Products.
-    await InAppPurchaseRepoImpl.ensureIosPaymentQueueDelegate();
-    _purchaseSub = InAppPurchase.instance.purchaseStream.listen(
-      (purchases) => add(SubscriptionPurchaseBatch(purchases)),
-      onError: (Object e) =>
-          add(SubscriptionPurchaseStreamFailed(e.toString())),
-    );
   }
 
   void _onPurchaseStreamFailed(
@@ -230,24 +237,28 @@ class SubscriptionBloc extends Bloc<SubscriptionEvent, SubscriptionState> {
   ) async {
     final uid = _uid;
     if (uid == null || uid.isEmpty) {
-      // Do not silently drop store updates — that looks like "Continue did nothing".
-      final bool hasTerminal = event.purchases.any(
+      // Buffer until uid arrives — do not snackbar+drop (store may not re-emit).
+      _pendingPurchases.addAll(event.purchases);
+      final bool showProgress = event.purchases.any(
         (p) =>
+            p.status == PurchaseStatus.pending ||
             p.status == PurchaseStatus.purchased ||
-            p.status == PurchaseStatus.restored ||
-            p.status == PurchaseStatus.error,
+            p.status == PurchaseStatus.restored,
       );
-      if (hasTerminal) {
-        emit(state.copyWith(
-          purchaseInProgress: false,
-          userMessage:
-              'Please sign in again to finish activating Premium.',
-        ));
+      if (showProgress) {
+        emit(state.copyWith(purchaseInProgress: true));
       }
       return;
     }
 
-    for (final purchase in event.purchases) {
+    await _processPurchaseBatch(event.purchases, emit);
+  }
+
+  Future<void> _processPurchaseBatch(
+    List<PurchaseDetails> purchases,
+    Emitter<SubscriptionState> emit,
+  ) async {
+    for (final purchase in purchases) {
       final key =
           '${purchase.purchaseID ?? ""}|${purchase.productID}|${purchase.status.name}';
       if (_processedKeys.contains(key)) continue;

--- a/lib/features/payment/ui/in_app_purchase/buy_products/buyproducts_bloc.dart
+++ b/lib/features/payment/ui/in_app_purchase/buy_products/buyproducts_bloc.dart
@@ -14,10 +14,10 @@ class BuyConsumableInAppProductsBloc
     on<RequestBuyConsumableProducts>((event, emit) async {
       emit(BuyConsumableLoadingState());
       try {
-        final result = await inAppPurchaseRepository.buyConsumable(
+        await inAppPurchaseRepository.buyConsumable(
           productDetails: event.productDetails,
         );
-        emit(BuyConsumableSuccessState(result: result));
+        emit(BuyConsumableSuccessState(result: true));
       } on SocketException {
         emit(BuyConsumableFailedState(msg: 'No Internet Connection'));
       } on Object catch (e) {
@@ -38,10 +38,10 @@ class BuyConsumableInAppProductsBloc
       yield BuyConsumableLoadingState();
 
       try {
-        final result = await inAppPurchaseRepository.buyConsumable(
+        await inAppPurchaseRepository.buyConsumable(
           productDetails: event.productDetails,
         );
-        yield BuyConsumableSuccessState(result: result);
+        yield BuyConsumableSuccessState(result: true);
       } on SocketException {
         yield BuyConsumableFailedState(msg: 'No Internet Connection');
       } on Object catch (e) {

--- a/lib/features/payment/ui/products.dart
+++ b/lib/features/payment/ui/products.dart
@@ -105,6 +105,12 @@ class _ProductsBodyState extends State<_ProductsBody> {
   void initState() {
     super.initState();
     context.read<GetInAppProductsBloc>().add(RequestInAppProducts());
+    // Keep SubscriptionBloc's purchaseStream listener in sync with the user
+    // shown on this paywall (UserBloc can lag or be UserLoaded(null)).
+    final String? paywallUid = widget.currentUser?.id;
+    if (paywallUid != null && paywallUid.isNotEmpty) {
+      context.read<SubscriptionBloc>().add(SubscriptionUserChanged(paywallUid));
+    }
     if (widget.isPaymentSuccess != null && !widget.isPaymentSuccess!) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         unawaited(
@@ -491,25 +497,33 @@ class _ProductsBodyState extends State<_ProductsBody> {
                         padding: const EdgeInsets.only(
                           bottom: AppSpacing.sm,
                         ),
-                        child: AfropeepPrimaryButton(
-                          text: selectedProduct != null
-                              ? 'Continue with $selectedLabel'
-                              : 'Select a plan',
-                          onPressed: selectedProduct != null
-                              ? () {
-                                  final product = selectedProduct;
-                                  if (product == null) return;
-                                  BlocProvider.of<
-                                      BuyConsumableInAppProductsBloc>(
-                                    context,
-                                  ).add(
-                                    RequestBuyConsumableProducts(
-                                      productDetails: product,
-                                    ),
-                                  );
-                                }
-                              : null,
-                          borderRadius: AppSpacing.chipRadius,
+                        child: BlocBuilder<BuyConsumableInAppProductsBloc,
+                            BuyConsumableStates>(
+                          buildWhen: (previous, current) =>
+                              previous.runtimeType != current.runtimeType,
+                          builder: (context, buyState) {
+                            final bool buying =
+                                buyState is BuyConsumableLoadingState;
+                            return BlocBuilder<SubscriptionBloc,
+                                SubscriptionState>(
+                              buildWhen: (p, c) =>
+                                  p.purchaseInProgress != c.purchaseInProgress,
+                              builder: (context, subState) {
+                                final bool busy =
+                                    buying || subState.purchaseInProgress;
+                                return AfropeepPrimaryButton(
+                                  text: selectedProduct != null
+                                      ? 'Continue with $selectedLabel'
+                                      : 'Select a plan',
+                                  isLoading: busy,
+                                  onPressed: selectedProduct != null && !busy
+                                      ? () => _startPurchase(context)
+                                      : null,
+                                  borderRadius: AppSpacing.chipRadius,
+                                );
+                              },
+                            );
+                          },
                         ),
                       ),
 
@@ -609,6 +623,30 @@ class _ProductsBodyState extends State<_ProductsBody> {
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
+
+  void _startPurchase(BuildContext context) {
+    final ProductDetails? product = selectedProduct;
+    if (product == null) return;
+
+    final String? uid = widget.currentUser?.id;
+    if (uid == null || uid.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Please sign in again to subscribe.',
+          ),
+        ),
+      );
+      return;
+    }
+
+    // Re-assert uid so purchaseStream is attached before the store sheet.
+    context.read<SubscriptionBloc>().add(SubscriptionUserChanged(uid));
+
+    context.read<BuyConsumableInAppProductsBloc>().add(
+          RequestBuyConsumableProducts(productDetails: product),
+        );
+  }
 
   Widget _buildBenefitRow(IconData icon, String text, bool isDarkMode) {
     return ConstrainedBox(


### PR DESCRIPTION
## Summary
- **Premium paywall:** Continue no longer fails silently — surface buy start failures, show CTA loading, attach `purchaseStream` from the paywall user, iOS payment-queue delegate, Android offer tokens
- **Chat:** Own send (text/image) always pins to the live edge even when reading history; incoming messages still respect near-bottom follow

## Test plan
### Premium
- [ ] Hot restart on a physical device / TestFlight build
- [ ] Open Afropeep Premium → Monthly → Continue with Monthly
- [ ] Expect Apple/Google sheet, spinner, or snackbar (not silence)
- [ ] Sandbox Apple ID signed in for debug/TestFlight buys

### Chat
- [ ] Open a long thread, scroll into history, send — jumps to your new bubble
- [ ] Scroll up again; their message arrives — stay put
- [ ] Stay at bottom and send — no bounce/shake

### Automated
- [ ] `flutter test test/features/payment/products_screen_test.dart test/payment/in_app_purchase_repo_test.dart`