### PR TITLE
fix(payment): await IAP listener before buy; clear pending on logout

### DIFF
--- a/lib/features/payment/presentation/bloc/subscription_bloc.dart
+++ b/lib/features/payment/presentation/bloc/subscription_bloc.dart
@@ -142,10 +142,15 @@ class SubscriptionBloc extends Bloc<SubscriptionEvent, SubscriptionState> {
   String? _uid;
   final Set<String> _processedKeys = {};
 
-  /// Store updates that arrived before [_uid] was known. Flushed once a
-  /// non-empty uid is set. Cleared on logout / account switch so entitlements
-  /// are never applied to a different user.
+  /// Store updates that arrived before [_uid] was known (cold start only).
+  /// Cleared on logout / account switch. Never flushed after a signed-out period.
   final List<PurchaseDetails> _pendingPurchases = [];
+
+  /// When true, unsigned store updates may be buffered for the first login
+  /// (app cold start). After logout this is false so post-logout store events
+  /// are dropped instead of applied to the next account.
+  bool _bufferUnsignedPurchases = true;
+
   bool _awaitingRestore = false;
   Timer? _restoreTimer;
 
@@ -178,7 +183,12 @@ class SubscriptionBloc extends Bloc<SubscriptionEvent, SubscriptionState> {
       _pendingPurchases.clear();
       _processedKeys.clear();
     }
+    // Post-logout: never apply anything buffered while signed out.
+    if (!_bufferUnsignedPurchases) {
+      _pendingPurchases.clear();
+    }
     _uid = uid;
+    _bufferUnsignedPurchases = false;
 
     await _ensurePurchaseStreamListening();
 
@@ -212,9 +222,13 @@ class SubscriptionBloc extends Bloc<SubscriptionEvent, SubscriptionState> {
     final String? nextUid = event.uid;
     final bool uidChanged = nextUid != previousUid;
 
-    // Logout / signed-out: never keep store updates for a future account.
+    // Logout / signed-out: drop pending. Only disable unsigned buffering after a
+    // real logout (we previously had a uid) — not on cold-start UserInitial(null).
     if (nextUid == null || nextUid.isEmpty) {
       _pendingPurchases.clear();
+      if (previousUid != null && previousUid.isNotEmpty) {
+        _bufferUnsignedPurchases = false;
+      }
       _uid = nextUid;
       if (uidChanged) {
         _processedKeys.clear();
@@ -230,14 +244,20 @@ class SubscriptionBloc extends Bloc<SubscriptionEvent, SubscriptionState> {
       _pendingPurchases.clear();
     }
 
+    // Login after logout: unsigned batches must not be applied to the new user.
+    if (!_bufferUnsignedPurchases) {
+      _pendingPurchases.clear();
+    }
+
     _uid = nextUid;
+    _bufferUnsignedPurchases = false;
     if (uidChanged) {
       _processedKeys.clear();
     }
 
     await _ensurePurchaseStreamListening();
 
-    // Cold-start / loading race: uid arrived after store updates were buffered.
+    // Cold-start only: uid arrived after store updates were buffered.
     if (_pendingPurchases.isNotEmpty) {
       final List<PurchaseDetails> pending =
           List<PurchaseDetails>.from(_pendingPurchases);
@@ -285,7 +305,10 @@ class SubscriptionBloc extends Bloc<SubscriptionEvent, SubscriptionState> {
   ) async {
     final uid = _uid;
     if (uid == null || uid.isEmpty) {
-      // Buffer until uid arrives — do not snackbar+drop (store may not re-emit).
+      // Cold start only. After logout, drop — do not hand to the next login.
+      if (!_bufferUnsignedPurchases) {
+        return;
+      }
       _pendingPurchases.addAll(event.purchases);
       final bool showProgress = event.purchases.any(
         (p) =>

--- a/lib/features/payment/presentation/bloc/subscription_bloc.dart
+++ b/lib/features/payment/presentation/bloc/subscription_bloc.dart
@@ -142,8 +142,9 @@ class SubscriptionBloc extends Bloc<SubscriptionEvent, SubscriptionState> {
   String? _uid;
   final Set<String> _processedKeys = {};
 
-  /// Store updates that arrived before [_uid] was known. Flushed in
-  /// [_onUserChanged] once a non-empty uid is set.
+  /// Store updates that arrived before [_uid] was known. Flushed once a
+  /// non-empty uid is set. Cleared on logout / account switch so entitlements
+  /// are never applied to a different user.
   final List<PurchaseDetails> _pendingPurchases = [];
   bool _awaitingRestore = false;
   Timer? _restoreTimer;
@@ -162,35 +163,82 @@ class SubscriptionBloc extends Bloc<SubscriptionEvent, SubscriptionState> {
     }
   }
 
+  /// Awaitable: set [uid] and ensure `purchaseStream` is attached before buy.
+  ///
+  /// Prefer this over fire-and-forget [SubscriptionUserChanged] right before
+  /// starting a store purchase — [SubscriptionUserChanged] returns before the
+  /// async listener setup finishes.
+  Future<void> prepareForPurchase(String uid) async {
+    if (uid.isEmpty) {
+      throw ArgumentError.value(uid, 'uid', 'must be non-empty');
+    }
+
+    final String? previous = _uid;
+    if (previous != null && previous.isNotEmpty && previous != uid) {
+      _pendingPurchases.clear();
+      _processedKeys.clear();
+    }
+    _uid = uid;
+
+    await _ensurePurchaseStreamListening();
+
+    if (_pendingPurchases.isNotEmpty) {
+      final List<PurchaseDetails> pending =
+          List<PurchaseDetails>.from(_pendingPurchases);
+      _pendingPurchases.clear();
+      add(SubscriptionPurchaseBatch(pending));
+    }
+  }
+
+  Future<void> _ensurePurchaseStreamListening() async {
+    if (_purchaseSub != null) return;
+
+    final bool available = await InAppPurchase.instance.isAvailable();
+    if (!available) return;
+
+    await InAppPurchaseRepoImpl.ensureIosPaymentQueueDelegate();
+    _purchaseSub = InAppPurchase.instance.purchaseStream.listen(
+      (purchases) => add(SubscriptionPurchaseBatch(purchases)),
+      onError: (Object e) =>
+          add(SubscriptionPurchaseStreamFailed(e.toString())),
+    );
+  }
+
   Future<void> _onUserChanged(
     SubscriptionUserChanged event,
     Emitter<SubscriptionState> emit,
   ) async {
+    final String? previousUid = _uid;
     final String? nextUid = event.uid;
-    final bool uidChanged = nextUid != _uid;
+    final bool uidChanged = nextUid != previousUid;
+
+    // Logout / signed-out: never keep store updates for a future account.
+    if (nextUid == null || nextUid.isEmpty) {
+      _pendingPurchases.clear();
+      _uid = nextUid;
+      if (uidChanged) {
+        _processedKeys.clear();
+      }
+      await _ensurePurchaseStreamListening();
+      return;
+    }
+
+    // Account switch: drop any buffered updates from the previous session.
+    if (previousUid != null &&
+        previousUid.isNotEmpty &&
+        previousUid != nextUid) {
+      _pendingPurchases.clear();
+    }
+
     _uid = nextUid;
     if (uidChanged) {
       _processedKeys.clear();
     }
 
-    // Attach once. Paywall may re-assert the same uid; do not cancel/rebind
-    // (that can drop in-flight purchase updates).
-    if (_purchaseSub == null) {
-      final available = await InAppPurchase.instance.isAvailable();
-      if (available) {
-        // Official plugin guidance: subscribe to purchaseStream *before*
-        // buy/restore. We may attach before uid is known; batches are buffered.
-        await InAppPurchaseRepoImpl.ensureIosPaymentQueueDelegate();
-        _purchaseSub = InAppPurchase.instance.purchaseStream.listen(
-          (purchases) => add(SubscriptionPurchaseBatch(purchases)),
-          onError: (Object e) =>
-              add(SubscriptionPurchaseStreamFailed(e.toString())),
-        );
-      }
-    }
+    await _ensurePurchaseStreamListening();
 
-    // Reprocess anything that arrived while uid was still loading.
-    if (_uid != null && _uid!.isNotEmpty && _pendingPurchases.isNotEmpty) {
+    // Cold-start / loading race: uid arrived after store updates were buffered.
+    if (_pendingPurchases.isNotEmpty) {
       final List<PurchaseDetails> pending =
           List<PurchaseDetails>.from(_pendingPurchases);
       _pendingPurchases.clear();

--- a/lib/features/payment/ui/products.dart
+++ b/lib/features/payment/ui/products.dart
@@ -100,6 +100,7 @@ class _ProductsBody extends StatefulWidget {
 
 class _ProductsBodyState extends State<_ProductsBody> {
   ProductDetails? selectedProduct;
+  bool _preparingPurchase = false;
 
   @override
   void initState() {
@@ -509,8 +510,9 @@ class _ProductsBodyState extends State<_ProductsBody> {
                               buildWhen: (p, c) =>
                                   p.purchaseInProgress != c.purchaseInProgress,
                               builder: (context, subState) {
-                                final bool busy =
-                                    buying || subState.purchaseInProgress;
+                                final bool busy = buying ||
+                                    subState.purchaseInProgress ||
+                                    _preparingPurchase;
                                 return AfropeepPrimaryButton(
                                   text: selectedProduct != null
                                       ? 'Continue with $selectedLabel'
@@ -627,6 +629,7 @@ class _ProductsBodyState extends State<_ProductsBody> {
   Future<void> _startPurchase(BuildContext context) async {
     final ProductDetails? product = selectedProduct;
     if (product == null) return;
+    if (_preparingPurchase) return;
 
     final String? uid = widget.currentUser?.id;
     if (uid == null || uid.isEmpty) {
@@ -640,6 +643,7 @@ class _ProductsBodyState extends State<_ProductsBody> {
       return;
     }
 
+    setState(() => _preparingPurchase = true);
     try {
       // Await listener attach — fire-and-forget SubscriptionUserChanged can
       // still be mid-setup when buyNonConsumable presents the store sheet.
@@ -654,6 +658,10 @@ class _ProductsBodyState extends State<_ProductsBody> {
         ),
       );
       return;
+    } finally {
+      if (mounted) {
+        setState(() => _preparingPurchase = false);
+      }
     }
 
     if (!context.mounted) return;

--- a/lib/features/payment/ui/products.dart
+++ b/lib/features/payment/ui/products.dart
@@ -517,7 +517,7 @@ class _ProductsBodyState extends State<_ProductsBody> {
                                       : 'Select a plan',
                                   isLoading: busy,
                                   onPressed: selectedProduct != null && !busy
-                                      ? () => _startPurchase(context)
+                                      ? () => unawaited(_startPurchase(context))
                                       : null,
                                   borderRadius: AppSpacing.chipRadius,
                                 );
@@ -624,7 +624,7 @@ class _ProductsBodyState extends State<_ProductsBody> {
   // Helpers
   // ---------------------------------------------------------------------------
 
-  void _startPurchase(BuildContext context) {
+  Future<void> _startPurchase(BuildContext context) async {
     final ProductDetails? product = selectedProduct;
     if (product == null) return;
 
@@ -640,9 +640,23 @@ class _ProductsBodyState extends State<_ProductsBody> {
       return;
     }
 
-    // Re-assert uid so purchaseStream is attached before the store sheet.
-    context.read<SubscriptionBloc>().add(SubscriptionUserChanged(uid));
+    try {
+      // Await listener attach — fire-and-forget SubscriptionUserChanged can
+      // still be mid-setup when buyNonConsumable presents the store sheet.
+      await context.read<SubscriptionBloc>().prepareForPurchase(uid);
+    } on Object catch (e) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            userFacingPurchaseThrowableMessage(e),
+          ),
+        ),
+      );
+      return;
+    }
 
+    if (!context.mounted) return;
     context.read<BuyConsumableInAppProductsBloc>().add(
           RequestBuyConsumableProducts(productDetails: product),
         );


### PR DESCRIPTION
## Summary
Follow-up to #203 addressing Codex P1s that landed on develop→main [#204](https://github.com/tosyno87/naijaSingles/pull/204):

1. Await `prepareForPurchase(uid)` before starting the store purchase so `purchaseStream` is attached first
2. Clear buffered purchases on logout / account switch so entitlements are not applied to another user

## Test plan
- [ ] Continue with Monthly still presents store sheet
- [ ] No silent miss of purchase after Confirm
- [ ] Log out / switch account does not grant Premium from a prior buffered purchase


Made with [Cursor](https://cursor.com)