### PR TITLE
fix(ci): format chat screen and cover subscription IAP buffer logic

### DIFF
--- a/lib/features/messages/chat_thread_screen.dart
+++ b/lib/features/messages/chat_thread_screen.dart
@@ -58,6 +58,7 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
   String? _replyPreview;
   int _lastMessageCount = 0;
   String? _lastMessageId;
+
   /// After the user sends, pin to the live edge even if they were reading history
   /// (Tinder/Hinge-style). Incoming messages still respect [_isNearBottom].
   bool _pinToBottomAfterOwnSend = false;
@@ -463,8 +464,8 @@ class _ChatThreadScreenState extends State<ChatThreadScreen> {
                     final bool pinAfterOwnSend = _pinToBottomAfterOwnSend;
                     final bool newestIsOwn = messages.isNotEmpty &&
                         messages.last.senderId == _currentUserId;
-                    final bool followLiveEdge = _isNearBottom ||
-                        (pinAfterOwnSend && newestIsOwn);
+                    final bool followLiveEdge =
+                        _isNearBottom || (pinAfterOwnSend && newestIsOwn);
                     if (pinAfterOwnSend && newestIsOwn) {
                       _pinToBottomAfterOwnSend = false;
                     }

--- a/lib/features/payment/presentation/bloc/subscription_bloc.dart
+++ b/lib/features/payment/presentation/bloc/subscription_bloc.dart
@@ -118,8 +118,14 @@ class SubscriptionBloc extends Bloc<SubscriptionEvent, SubscriptionState> {
   SubscriptionBloc({
     required UserBloc userBloc,
     SubscriptionFunctionsService? functionsService,
+    Future<bool> Function()? isStoreAvailable,
+    Stream<List<PurchaseDetails>> Function()? purchaseUpdates,
   })  : _userBloc = userBloc,
         _functions = functionsService ?? SubscriptionFunctionsService(),
+        _isStoreAvailable =
+            isStoreAvailable ?? (() => InAppPurchase.instance.isAvailable()),
+        _purchaseUpdates =
+            purchaseUpdates ?? (() => InAppPurchase.instance.purchaseStream),
         super(const SubscriptionState()) {
     on<SubscriptionUserChanged>(_onUserChanged);
     on<SubscriptionPurchaseBatch>(_onPurchaseBatch);
@@ -135,6 +141,8 @@ class SubscriptionBloc extends Bloc<SubscriptionEvent, SubscriptionState> {
 
   final UserBloc _userBloc;
   final SubscriptionFunctionsService _functions;
+  final Future<bool> Function() _isStoreAvailable;
+  final Stream<List<PurchaseDetails>> Function() _purchaseUpdates;
 
   late final StreamSubscription<UserState> _userSub;
 
@@ -203,11 +211,11 @@ class SubscriptionBloc extends Bloc<SubscriptionEvent, SubscriptionState> {
   Future<void> _ensurePurchaseStreamListening() async {
     if (_purchaseSub != null) return;
 
-    final bool available = await InAppPurchase.instance.isAvailable();
+    final bool available = await _isStoreAvailable();
     if (!available) return;
 
     await InAppPurchaseRepoImpl.ensureIosPaymentQueueDelegate();
-    _purchaseSub = InAppPurchase.instance.purchaseStream.listen(
+    _purchaseSub = _purchaseUpdates().listen(
       (purchases) => add(SubscriptionPurchaseBatch(purchases)),
       onError: (Object e) =>
           add(SubscriptionPurchaseStreamFailed(e.toString())),

--- a/test/features/payment/products_screen_test.dart
+++ b/test/features/payment/products_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:naijasingles/common/bloc/theme/theme_bloc.dart';
 import 'package:naijasingles/common/bloc/user/user_bloc.dart';
 import 'package:naijasingles/features/payment/presentation/bloc/subscription_bloc.dart';
 import 'package:naijasingles/features/payment/ui/in_app_purchase/buy_products/buyproducts_bloc.dart';
+import 'package:naijasingles/features/payment/ui/in_app_purchase/buy_products/buyproducts_events.dart';
 import 'package:naijasingles/features/payment/ui/in_app_purchase/buy_products/buyproducts_states.dart';
 import 'package:naijasingles/features/payment/ui/in_app_purchase/get_products/getproducts_bloc.dart';
 import 'package:naijasingles/features/payment/ui/in_app_purchase/get_products/getproducts_events.dart';
@@ -33,6 +34,9 @@ class MockBuyConsumableBloc extends Mock
 class FakeGetInAppProductsEvents extends Fake
     implements GetInAppProductsEvents {}
 
+class FakeBuyInAppProductsEvents extends Fake
+    implements BuyInAppProductsEvents {}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -56,6 +60,7 @@ void main() {
   setUpAll(() async {
     await setupFirebaseForWidgetTests();
     registerFallbackValue(FakeGetInAppProductsEvents());
+    registerFallbackValue(FakeBuyInAppProductsEvents());
   });
 
   late MockThemeBloc themeBloc;
@@ -104,6 +109,7 @@ void main() {
     when(() => buyBloc.state).thenReturn(BuyConsumableInitialState());
     when(() => buyBloc.stream)
         .thenAnswer((_) => const Stream<BuyConsumableStates>.empty());
+    when(() => buyBloc.add(any())).thenReturn(null);
   });
 
   Widget buildSubject() {
@@ -114,7 +120,11 @@ void main() {
         BlocProvider<GetInAppProductsBloc>.value(value: getProductsBloc),
         BlocProvider<BuyConsumableInAppProductsBloc>.value(value: buyBloc),
         BlocProvider<SubscriptionBloc>(
-          create: (_) => SubscriptionBloc(userBloc: userBloc),
+          create: (_) => SubscriptionBloc(
+            userBloc: userBloc,
+            isStoreAvailable: () async => false,
+            purchaseUpdates: () => const Stream<List<PurchaseDetails>>.empty(),
+          ),
         ),
       ],
       child: Products(
@@ -176,6 +186,21 @@ void main() {
         // yearly = $79.99/12 ≈ $6.67/mo vs monthly $9.99/mo → ~33% savings
         expect(find.textContaining('Save'), findsOneWidget);
         expect(find.textContaining('%'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Continue prepares listener then dispatches buy',
+      (tester) async {
+        await tester.pumpWidget(MaterialApp(home: buildSubject()));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Continue with Monthly'));
+        // prepareForPurchase awaits store availability; avoid pumpAndSettle.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 200));
+
+        verify(() => buyBloc.add(any())).called(1);
       },
     );
   });

--- a/test/features/payment/subscription_bloc_test.dart
+++ b/test/features/payment/subscription_bloc_test.dart
@@ -1,0 +1,213 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:in_app_purchase/in_app_purchase.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:naijasingles/common/bloc/user/user_bloc.dart';
+import 'package:naijasingles/features/payment/data/subscription_functions_service.dart';
+import 'package:naijasingles/features/payment/presentation/bloc/subscription_bloc.dart';
+
+class MockUserBloc extends Mock implements UserBloc {}
+
+class MockSubscriptionFunctionsService extends Mock
+    implements SubscriptionFunctionsService {}
+
+class FakeUserEvent extends Fake implements UserEvent {}
+
+PurchaseDetails _purchase({
+  required String productId,
+  PurchaseStatus status = PurchaseStatus.purchased,
+}) =>
+    PurchaseDetails(
+      productID: productId,
+      purchaseID: 'p-$productId',
+      verificationData: PurchaseVerificationData(
+        localVerificationData: 'local',
+        serverVerificationData: 'server',
+        source: 'test',
+      ),
+      transactionDate: '0',
+      status: status,
+    );
+
+void main() {
+  late MockUserBloc userBloc;
+  late MockSubscriptionFunctionsService functions;
+
+  setUpAll(() {
+    registerFallbackValue(FakeUserEvent());
+  });
+
+  setUp(() {
+    userBloc = MockUserBloc();
+    functions = MockSubscriptionFunctionsService();
+    when(() => userBloc.state).thenReturn(const UserInitial());
+    when(() => userBloc.stream)
+        .thenAnswer((_) => const Stream<UserState>.empty());
+    when(() => userBloc.add(any())).thenReturn(null);
+    when(
+      () => functions.verifySubscriptionPurchase(
+        platform: any(named: 'platform'),
+        productId: any(named: 'productId'),
+        purchaseToken: any(named: 'purchaseToken'),
+        receiptData: any(named: 'receiptData'),
+        packageName: any(named: 'packageName'),
+      ),
+    ).thenAnswer((_) async => 'ok');
+  });
+
+  SubscriptionBloc buildBloc() => SubscriptionBloc(
+        userBloc: userBloc,
+        functionsService: functions,
+        isStoreAvailable: () async => false,
+        purchaseUpdates: () => const Stream<List<PurchaseDetails>>.empty(),
+      );
+
+  group('SubscriptionBloc.prepareForPurchase', () {
+    test('throws when uid is empty', () async {
+      final SubscriptionBloc bloc = buildBloc();
+      expect(
+        () => bloc.prepareForPurchase(''),
+        throwsA(isA<ArgumentError>()),
+      );
+      await bloc.close();
+    });
+
+    blocTest<SubscriptionBloc, SubscriptionState>(
+      'sets uid so later batches are verified for that user',
+      build: buildBloc,
+      act: (SubscriptionBloc bloc) async {
+        // Drain constructor-triggered SubscriptionUserChanged(null).
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        await bloc.prepareForPurchase('user-a');
+        bloc.add(
+          SubscriptionPurchaseBatch([
+            _purchase(productId: 'premium.monthly'),
+          ]),
+        );
+      },
+      wait: const Duration(milliseconds: 50),
+      verify: (_) {
+        verify(
+          () => functions.verifySubscriptionPurchase(
+            platform: any(named: 'platform'),
+            productId: 'premium.monthly',
+            purchaseToken: any(named: 'purchaseToken'),
+            receiptData: any(named: 'receiptData'),
+            packageName: any(named: 'packageName'),
+          ),
+        ).called(1);
+      },
+    );
+  });
+
+  group('SubscriptionBloc unsigned purchase buffering', () {
+    blocTest<SubscriptionBloc, SubscriptionState>(
+      'cold start: buffers purchased update while uid is null',
+      build: buildBloc,
+      act: (SubscriptionBloc bloc) {
+        bloc.add(
+          SubscriptionPurchaseBatch([
+            _purchase(productId: 'premium.monthly'),
+          ]),
+        );
+      },
+      expect: () => [
+        isA<SubscriptionState>().having(
+          (SubscriptionState s) => s.purchaseInProgress,
+          'purchaseInProgress',
+          isTrue,
+        ),
+      ],
+      verify: (_) {
+        verifyNever(
+          () => functions.verifySubscriptionPurchase(
+            platform: any(named: 'platform'),
+            productId: any(named: 'productId'),
+            purchaseToken: any(named: 'purchaseToken'),
+            receiptData: any(named: 'receiptData'),
+            packageName: any(named: 'packageName'),
+          ),
+        );
+      },
+    );
+
+    blocTest<SubscriptionBloc, SubscriptionState>(
+      'after logout, unsigned batches are dropped (not applied on next login)',
+      build: buildBloc,
+      act: (SubscriptionBloc bloc) async {
+        // Establish a signed-in session, then log out.
+        bloc.add(const SubscriptionUserChanged('user-a'));
+        await Future<void>.delayed(Duration.zero);
+        bloc.add(const SubscriptionUserChanged(null));
+        await Future<void>.delayed(Duration.zero);
+
+        // Store update while signed out — must be dropped.
+        bloc.add(
+          SubscriptionPurchaseBatch([
+            _purchase(productId: 'premium.monthly'),
+          ]),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        // Next login must not verify the signed-out purchase.
+        bloc.add(const SubscriptionUserChanged('user-b'));
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+      },
+      verify: (_) {
+        verifyNever(
+          () => functions.verifySubscriptionPurchase(
+            platform: any(named: 'platform'),
+            productId: any(named: 'productId'),
+            purchaseToken: any(named: 'purchaseToken'),
+            receiptData: any(named: 'receiptData'),
+            packageName: any(named: 'packageName'),
+          ),
+        );
+      },
+    );
+
+    blocTest<SubscriptionBloc, SubscriptionState>(
+      'cold start buffer is flushed when first uid arrives',
+      build: buildBloc,
+      act: (SubscriptionBloc bloc) async {
+        bloc.add(
+          SubscriptionPurchaseBatch([
+            _purchase(productId: 'premium.yearly'),
+          ]),
+        );
+        await Future<void>.delayed(Duration.zero);
+        bloc.add(const SubscriptionUserChanged('user-cold'));
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+      },
+      verify: (_) {
+        verify(
+          () => functions.verifySubscriptionPurchase(
+            platform: any(named: 'platform'),
+            productId: 'premium.yearly',
+            purchaseToken: any(named: 'purchaseToken'),
+            receiptData: any(named: 'receiptData'),
+            packageName: any(named: 'packageName'),
+          ),
+        ).called(1);
+      },
+    );
+  });
+
+  group('SubscriptionBloc consume events', () {
+    blocTest<SubscriptionBloc, SubscriptionState>(
+      'consume user message clears it',
+      build: buildBloc,
+      seed: () => const SubscriptionState(userMessage: 'Hello'),
+      act: (SubscriptionBloc bloc) =>
+          bloc.add(const SubscriptionConsumeUserMessage()),
+      expect: () => [
+        isA<SubscriptionState>().having(
+          (SubscriptionState s) => s.userMessage,
+          'userMessage',
+          isNull,
+        ),
+      ],
+    );
+  });
+}


### PR DESCRIPTION
## Summary
Follow-up after #205 merged: that PR’s CI was still red for format + Sonar new-code coverage. This lands the post-merge commit that did not make it into #205.

- `dart format` on `chat_thread_screen.dart` (Quality Gates format check)
- `subscription_bloc_test.dart` + Continue CTA coverage in `products_screen_test.dart`
- Injectable store hooks on `SubscriptionBloc` for unit tests

## Test plan
- [ ] `flutter test test/features/payment/subscription_bloc_test.dart test/features/payment/products_screen_test.dart`
- [ ] CI Code Quality Analysis / SonarCloud pass on this PR


Made with [Cursor](https://cursor.com)