### PR TITLE
fix(maps): prevent TestFlight GoogleMap crash without GMSApiKey

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -86,6 +86,8 @@ jobs:
           
       - name: Create .env file for CI
         # SonarQube: Values are securely injected from GitHub Secrets (not hard-coded)
+        # Also sync Maps keys into iOS Secrets.xcconfig + assets/env/app.env so
+        # TestFlight builds get GMSApiKey (avoids GoogleMap hard crash) and Places HTTP.
         run: |
           cat > .env << EOF
           FIREBASE_WEB_API_KEY=${{ secrets.FIREBASE_WEB_API_KEY_PROD }}
@@ -98,8 +100,15 @@ jobs:
           FIREBASE_IOS_CLIENT_ID=${{ secrets.FIREBASE_IOS_CLIENT_ID_PROD }}
           FIREBASE_IOS_BUNDLE_ID=com.app.naijasingles
           GOOGLE_MAPS_API_KEY=${{ secrets.GOOGLE_MAPS_API_KEY_PROD }}
+          GOOGLE_MAPS_WEB_API_KEY=${{ secrets.GOOGLE_MAPS_WEB_API_KEY_PROD || secrets.GOOGLE_MAPS_API_KEY_PROD }}
           APP_ENVIRONMENT=production
           EOF
+          # Strip accidental leading whitespace from indented heredoc lines.
+          sed -i.bak 's/^[[:space:]]*//' .env && rm -f .env.bak
+          python3 tool/sync_maps_secrets_from_env.py
+          test -s ios/Flutter/Secrets.xcconfig
+          test -s assets/env/app.env
+          echo "✅ Maps secrets synced for iOS + Dart assets"
           
       - name: Install dependencies
         run: flutter pub get
@@ -273,6 +282,8 @@ jobs:
           ./scripts/verify_release_firebase_config.sh
           flutter pub get
           flutter build ios --release --dart-define=ENV=production --no-codesign
+          chmod +x scripts/verify_ios_gms_api_key.sh
+          ./scripts/verify_ios_gms_api_key.sh
           cd ios
           bundle exec fastlane build_app
         
@@ -372,6 +383,8 @@ jobs:
               flutter clean
               flutter pub get
               flutter build ios --release --dart-define=ENV=production --no-codesign
+              chmod +x scripts/verify_ios_gms_api_key.sh
+              ./scripts/verify_ios_gms_api_key.sh
               cd ios
               pod install
               SKIP_FLUTTER_CLEAN=true bundle exec fastlane build_app

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -4,6 +4,9 @@ import GoogleMaps
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
+  private var mapsApiKeyConfigured = false
+  private var mapsChannelRegistered = false
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
@@ -13,11 +16,46 @@ import GoogleMaps
        !apiKey.isEmpty,
        !apiKey.hasPrefix("$(") {
       GMSServices.provideAPIKey(apiKey)
+      mapsApiKeyConfigured = true
     } else {
+      mapsApiKeyConfigured = false
       NSLog("⚠️ GMSApiKey missing — set GOOGLE_MAPS_API_KEY in ios/Flutter/Secrets.xcconfig")
     }
+    UserDefaults.standard.set(mapsApiKeyConfigured, forKey: "afropeep.mapsApiKeyConfigured")
 
     GeneratedPluginRegistrant.register(with: self)
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    let launched = super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    // window/root VC often nil until after super — register channel on next runloop.
+    DispatchQueue.main.async { [weak self] in
+      self?.registerMapsConfigChannel()
+    }
+    return launched
+  }
+
+  private func registerMapsConfigChannel() {
+    guard !mapsChannelRegistered else { return }
+    guard let controller = window?.rootViewController as? FlutterViewController else {
+      // Retry once shortly after first frame.
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+        self?.registerMapsConfigChannel()
+      }
+      return
+    }
+    let channel = FlutterMethodChannel(
+      name: "com.app.naijasingles/maps_config",
+      binaryMessenger: controller.binaryMessenger
+    )
+    channel.setMethodCallHandler { [weak self] call, result in
+      guard let self = self else {
+        result(FlutterError(code: "gone", message: nil, details: nil))
+        return
+      }
+      if call.method == "isMapsApiKeyConfigured" {
+        result(self.mapsApiKeyConfigured)
+      } else {
+        result(FlutterMethodNotImplemented)
+      }
+    }
+    mapsChannelRegistered = true
   }
 }

--- a/lib/common/widgets/native_maps_gate.dart
+++ b/lib/common/widgets/native_maps_gate.dart
@@ -1,0 +1,83 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../config/native_maps_config.dart';
+import '../constants/app_colors.dart';
+
+/// Defers constructing a [GoogleMap] until the native Maps SDK key is confirmed.
+///
+/// Use a [builder] (not a pre-built child) so `GoogleMap(...)` is not evaluated
+/// when the key is missing — that path hard-crashes iOS TestFlight builds.
+class NativeMapsGate extends StatefulWidget {
+  const NativeMapsGate({
+    required this.builder,
+    this.fallback,
+    this.loading,
+    super.key,
+  });
+
+  /// Built only when [NativeMapsConfig.isApiKeyConfigured] is true.
+  final WidgetBuilder builder;
+
+  /// Shown when the native key is missing. Defaults to a short message.
+  final WidgetBuilder? fallback;
+
+  /// Shown while the platform channel is resolving.
+  final Widget? loading;
+
+  @override
+  State<NativeMapsGate> createState() => _NativeMapsGateState();
+}
+
+class _NativeMapsGateState extends State<NativeMapsGate> {
+  bool? _configured;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_resolve());
+  }
+
+  Future<void> _resolve() async {
+    final bool ok = await NativeMapsConfig.ensureConfigured();
+    if (!mounted) return;
+    setState(() => _configured = ok);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool? configured = _configured;
+    if (configured == null) {
+      return widget.loading ??
+          const Center(
+            child: SizedBox(
+              width: 28,
+              height: 28,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+          );
+    }
+    if (!configured) {
+      if (widget.fallback != null) return widget.fallback!(context);
+      return ColoredBox(
+        color: const Color(0xFFE8E8E8),
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text(
+              'Map unavailable on this build.',
+              textAlign: TextAlign.center,
+              style: GoogleFonts.montserrat(
+                color: AppColors.textSecondary,
+                fontSize: 14,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+    return widget.builder(context);
+  }
+}

--- a/lib/config/native_maps_config.dart
+++ b/lib/config/native_maps_config.dart
@@ -1,0 +1,50 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// Whether the native Google Maps SDK received a real API key at launch.
+///
+/// iOS reads `GMSApiKey` from Info.plist (Secrets.xcconfig). Creating a
+/// [GoogleMap] without that key can hard-crash the process (TestFlight).
+class NativeMapsConfig {
+  NativeMapsConfig._();
+
+  static const MethodChannel _channel =
+      MethodChannel('com.app.naijasingles/maps_config');
+
+  static bool? _cached;
+
+  /// Returns true when native Maps was configured; false when missing.
+  /// On non-iOS platforms, returns true (Android uses manifest placeholder).
+  static Future<bool> isApiKeyConfigured({bool forceRefresh = false}) async {
+    if (!forceRefresh && _cached != null) return _cached!;
+    if (kIsWeb || !Platform.isIOS) {
+      _cached = true;
+      return true;
+    }
+    try {
+      final Object? value =
+          await _channel.invokeMethod<Object?>('isMapsApiKeyConfigured');
+      _cached = value == true;
+    } on Object {
+      // Channel not ready / older build. In release, fail closed so we never
+      // construct GoogleMap without a confirmed native key (TestFlight crash).
+      _cached = !kReleaseMode;
+    }
+    return _cached!;
+  }
+
+  /// Clears the cached result so the next call re-queries the platform channel.
+  static void clearCache() => _cached = null;
+
+  /// Queries once, then retries after a short delay if the channel was not ready.
+  static Future<bool> ensureConfigured() async {
+    clearCache();
+    final bool configured = await isApiKeyConfigured(forceRefresh: true);
+    if (configured) return true;
+    await Future<void>.delayed(const Duration(milliseconds: 400));
+    clearCache();
+    return isApiKeyConfigured(forceRefresh: true);
+  }
+}

--- a/lib/features/explore/explore_map.dart
+++ b/lib/features/explore/explore_map.dart
@@ -13,6 +13,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import '../../common/bloc/theme/theme_bloc.dart';
 import '../../common/constants/app_colors.dart';
 import '../../common/data/repo/user_location_repo.dart';
+import '../../common/widgets/native_maps_gate.dart';
 import '../../models/user_model.dart';
 import 'bloc/explore_map_bloc.dart';
 
@@ -175,30 +176,32 @@ class _ExploreMapWidgetState extends State<ExploreMapWidget>
                         ],
                       ),
                     )
-                  : GoogleMap(
-                      // Native Maps SDK uses the platform key (iOS Secrets /
-                      // Android manifest), not the Dart env Places key.
-                      onMapCreated: (GoogleMapController controller) {
-                        // Map initialization
-                      },
-                      initialCameraPosition: CameraPosition(
-                        target: LatLng(
-                          widget.currentUser.latitude ?? 0.0,
-                          widget.currentUser.longitude ?? 0.0,
+                  : NativeMapsGate(
+                      builder: (_) => GoogleMap(
+                        // Native Maps SDK uses the platform key (iOS Secrets /
+                        // Android manifest), not the Dart env Places key.
+                        onMapCreated: (GoogleMapController controller) {
+                          // Map initialization
+                        },
+                        initialCameraPosition: CameraPosition(
+                          target: LatLng(
+                            widget.currentUser.latitude ?? 0.0,
+                            widget.currentUser.longitude ?? 0.0,
+                          ),
+                          zoom: 14,
                         ),
-                        zoom: 14,
-                      ),
-                      markers: Set<Marker>.from(
-                        state.users.map(
-                          (user) => Marker(
-                            markerId: MarkerId(user.id ?? ''),
-                            position: LatLng(
-                              user.latitude ?? 0.0,
-                              user.longitude ?? 0.0,
-                            ),
-                            infoWindow: InfoWindow(
-                              title: user.name,
-                              snippet: '${user.age} years old',
+                        markers: Set<Marker>.from(
+                          state.users.map(
+                            (user) => Marker(
+                              markerId: MarkerId(user.id ?? ''),
+                              position: LatLng(
+                                user.latitude ?? 0.0,
+                                user.longitude ?? 0.0,
+                              ),
+                              infoWindow: InfoWindow(
+                                title: user.name,
+                                snippet: '${user.age} years old',
+                              ),
                             ),
                           ),
                         ),

--- a/lib/features/explore/premium_map.dart
+++ b/lib/features/explore/premium_map.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 import '../../common/constants/app_colors.dart';
+import '../../common/widgets/native_maps_gate.dart';
 import '../../models/user_model.dart';
 import '../payment/ui/products.dart';
 
@@ -40,18 +41,20 @@ class GoogleMapWidgetState extends State<GoogleMapWidget> {
   @override
   Widget build(BuildContext context) {
     // Native Maps SDK is keyed via platform config (AndroidManifest /
-    // GMSApiKey). Do not gate on the Dart/env Places HTTP key.
-    return GoogleMap(
-      mapToolbarEnabled: false,
-      myLocationButtonEnabled: false,
-      compassEnabled: false,
-      scrollGesturesEnabled: false,
-      initialCameraPosition: CameraPosition(
-        target: LatLng(
-          widget.currentUser.latitude!,
-          widget.currentUser.longitude!,
+    // GMSApiKey). Do not construct GoogleMap without a confirmed native key.
+    return NativeMapsGate(
+      builder: (_) => GoogleMap(
+        mapToolbarEnabled: false,
+        myLocationButtonEnabled: false,
+        compassEnabled: false,
+        scrollGesturesEnabled: false,
+        initialCameraPosition: CameraPosition(
+          target: LatLng(
+            widget.currentUser.latitude!,
+            widget.currentUser.longitude!,
+          ),
+          zoom: 15,
         ),
-        zoom: 15,
       ),
     );
   }

--- a/lib/features/user/ui/screens/update_user_location.dart
+++ b/lib/features/user/ui/screens/update_user_location.dart
@@ -11,6 +11,7 @@ import '../../../../common/constants/app_colors.dart';
 import '../../../../common/data/repo/user_location_repo.dart';
 import '../../../../common/widgets/afropeep_primary_button.dart';
 import '../../../../common/widgets/hookup_circularbar.dart';
+import '../../../../common/widgets/native_maps_gate.dart';
 import '../../../../config/app_config.dart';
 import '../widgets/location_savedailog.dart';
 import 'place_search_page.dart';
@@ -322,7 +323,8 @@ class UpdateLocationState extends State<UpdateLocation> {
                     fit: StackFit.expand,
                     children: [
                       // Native Maps SDK uses platform keys; only wait for a
-                      // camera target before showing GoogleMap.
+                      // camera target before showing GoogleMap. Gate so we
+                      // never construct GoogleMap without GMSApiKey (crash).
                       if (target == null)
                         ColoredBox(
                           color: isDark
@@ -340,36 +342,54 @@ class UpdateLocationState extends State<UpdateLocation> {
                           ),
                         )
                       else
-                        GoogleMap(
-                          initialCameraPosition: CameraPosition(
-                            target: target,
-                            zoom: 16,
-                          ),
-                          onMapCreated: (GoogleMapController c) {
-                            googleMapController = c;
-                          },
-                          myLocationEnabled: false,
-                          zoomControlsEnabled: false,
-                          compassEnabled: false,
-                          mapToolbarEnabled: false,
-                          markers: <Marker>{
-                            Marker(
-                              markerId: const MarkerId('selected'),
-                              position: LatLng(latitude!, longitude!),
-                              draggable: true,
-                              onDragEnd: (LatLng loc) {
-                                unawaited(_refreshLabelForPin(loc));
-                              },
-                            ),
-                          },
-                          onLongPress: (LatLng position) {
-                            unawaited(_refreshLabelForPin(position));
-                            unawaited(
-                              googleMapController?.animateCamera(
-                                CameraUpdate.newLatLng(position),
+                        NativeMapsGate(
+                          fallback: (_) => ColoredBox(
+                            color: isDark
+                                ? const Color(0xFF2A2A2A)
+                                : const Color(0xFFE8E8E8),
+                            child: Center(
+                              child: Padding(
+                                padding: const EdgeInsets.all(24),
+                                child: Text(
+                                  'Map preview unavailable on this build. '
+                                  'You can still search or use current location.',
+                                  textAlign: TextAlign.center,
+                                  style: GoogleFonts.montserrat(color: muted),
+                                ),
                               ),
-                            );
-                          },
+                            ),
+                          ),
+                          builder: (_) => GoogleMap(
+                            initialCameraPosition: CameraPosition(
+                              target: target,
+                              zoom: 16,
+                            ),
+                            onMapCreated: (GoogleMapController c) {
+                              googleMapController = c;
+                            },
+                            myLocationEnabled: false,
+                            zoomControlsEnabled: false,
+                            compassEnabled: false,
+                            mapToolbarEnabled: false,
+                            markers: <Marker>{
+                              Marker(
+                                markerId: const MarkerId('selected'),
+                                position: LatLng(latitude!, longitude!),
+                                draggable: true,
+                                onDragEnd: (LatLng loc) {
+                                  unawaited(_refreshLabelForPin(loc));
+                                },
+                              ),
+                            },
+                            onLongPress: (LatLng position) {
+                              unawaited(_refreshLabelForPin(position));
+                              unawaited(
+                                googleMapController?.animateCamera(
+                                  CameraUpdate.newLatLng(position),
+                                ),
+                              );
+                            },
+                          ),
                         ),
                       if (_loadingGps)
                         const Positioned(

--- a/scripts/verify_ios_gms_api_key.sh
+++ b/scripts/verify_ios_gms_api_key.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Verify the built iOS app has a resolved (non-empty) GMSApiKey.
+# Usage: scripts/verify_ios_gms_api_key.sh [path/to/Runner.app]
+set -euo pipefail
+
+APP="${1:-}"
+if [[ -z "$APP" ]]; then
+  APP="$(find build/ios -name 'Runner.app' -type d 2>/dev/null | head -1 || true)"
+fi
+
+if [[ -z "$APP" || ! -d "$APP" ]]; then
+  echo "❌ Runner.app not found (pass path or build iOS first)"
+  exit 1
+fi
+
+PLIST="$APP/Info.plist"
+if [[ ! -f "$PLIST" ]]; then
+  echo "❌ Info.plist missing at $PLIST"
+  exit 1
+fi
+
+KEY="$(/usr/libexec/PlistBuddy -c 'Print :GMSApiKey' "$PLIST" 2>/dev/null || true)"
+if [[ -z "$KEY" ]]; then
+  echo "❌ GMSApiKey is empty in $PLIST — Maps will hard-crash on GoogleMap"
+  exit 1
+fi
+if [[ "$KEY" == \$\(* ]]; then
+  echo "❌ GMSApiKey was not substituted (still '$KEY') — Secrets.xcconfig missing in CI"
+  exit 1
+fi
+
+echo "✅ GMSApiKey present in $(basename "$APP") (len=${#KEY})"

--- a/tool/sync_maps_secrets_from_env.py
+++ b/tool/sync_maps_secrets_from_env.py
@@ -19,7 +19,8 @@ from pathlib import Path
 
 def _read_env_value(env_text: str, key: str) -> str | None:
     prefix = f"{key}="
-    for line in env_text.splitlines():
+    for raw in env_text.splitlines():
+        line = raw.strip()
         if line.startswith(prefix):
             return line.split("=", 1)[1].strip().strip('"').strip("'")
     return None


### PR DESCRIPTION
## Summary
- Production CI syncs Maps keys into `ios/Flutter/Secrets.xcconfig` + `assets/env/app.env`, then verifies the built `Runner.app` has a non-empty `GMSApiKey`.
- Adds `NativeMapsGate` / `NativeMapsConfig` so every `GoogleMap` (Choose Location, Explore, Premium) is only constructed when the native Maps SDK key is configured — avoids TestFlight hard crashes to SpringBoard.
- AppDelegate exposes Maps key configuration over a method channel and only calls `GMSServices.provideAPIKey` when the key is real.

## Test plan
- [ ] USB/debug: Choose location map still loads with local `Secrets.xcconfig`
- [ ] USB/debug: Explore / premium map screens still open without crash
- [ ] Confirm CI step `verify_ios_gms_api_key.sh` passes on production build
- [ ] After TestFlight deploy: open Choose location — app must not kick to iPhone home screen
- [ ] Optional: confirm place search still works when `GOOGLE_MAPS_WEB_API_KEY` is present in synced `app.env`


Made with [Cursor](https://cursor.com)