### PR TITLE
fix(ci): fail fast with clear error when Maps prod secret missing

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -105,6 +105,11 @@ jobs:
           EOF
           # Strip accidental leading whitespace from indented heredoc lines.
           sed -i.bak 's/^[[:space:]]*//' .env && rm -f .env.bak
+          if ! grep -q '^GOOGLE_MAPS_API_KEY=.' .env; then
+            echo "::error::Repository secret GOOGLE_MAPS_API_KEY_PROD is missing or empty."
+            echo "::error::Add it in Settings → Secrets and variables → Actions, then re-run this workflow."
+            exit 1
+          fi
           python3 tool/sync_maps_secrets_from_env.py
           test -s ios/Flutter/Secrets.xcconfig
           test -s assets/env/app.env


### PR DESCRIPTION
## Summary
- Production CI now emits an explicit Actions error when `GOOGLE_MAPS_API_KEY_PROD` is missing/empty before running the Maps sync script.

## Context
Run https://github.com/tosyno87/naijaSingles/actions/runs/29970670311 failed because that secret was not configured. The Maps sync step is intentionally required to prevent TestFlight `GoogleMap` hard crashes.

## Test plan
- [ ] With secret set, Create .env step succeeds and sync prints key lengths
- [ ] With secret unset, step fails with the new `::error::` annotation

Made with [Cursor](https://cursor.com)