### PR TITLE
fix(boost): restore timer, separate Premium, and ship legal site pages

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "public": "web",
+    "public": "build/web",
     "ignore": [
       "firebase.json",
       "**/.*",

--- a/firebase.json
+++ b/firebase.json
@@ -1,12 +1,58 @@
 {
   "hosting": {
-    "public": "build/web",
+    "public": "web",
     "ignore": [
       "firebase.json",
       "**/.*",
       "**/node_modules/**"
     ],
+    "headers": [
+      {
+        "source": "/privacy",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      },
+      {
+        "source": "/privacy/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      },
+      {
+        "source": "/terms",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      },
+      {
+        "source": "/terms/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      }
+    ],
     "rewrites": [
+      {
+        "source": "/privacy",
+        "destination": "/privacy/index.html"
+      },
+      {
+        "source": "/terms",
+        "destination": "/terms/index.html"
+      },
       {
         "source": "**",
         "destination": "/index.html"

--- a/firebase.json
+++ b/firebase.json
@@ -42,6 +42,24 @@
             "value": "no-cache"
           }
         ]
+      },
+      {
+        "source": "/community-guidelines",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      },
+      {
+        "source": "/community-guidelines/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
       }
     ],
     "rewrites": [
@@ -52,6 +70,10 @@
       {
         "source": "/terms",
         "destination": "/terms/index.html"
+      },
+      {
+        "source": "/community-guidelines",
+        "destination": "/community-guidelines/index.html"
       },
       {
         "source": "**",

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -143,6 +143,20 @@
           "order": "ASCENDING"
         },
         {
+          "fieldPath": "boostExpiresAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "users",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "isDiscoverable",
+          "order": "ASCENDING"
+        },
+        {
           "fieldPath": "age",
           "order": "ASCENDING"
         }

--- a/lib/common/data/repo/user_search_repo.dart
+++ b/lib/common/data/repo/user_search_repo.dart
@@ -43,7 +43,9 @@ class UserSearchRepo {
 
   static Future<Set<String>> _activeBoostedUserIds() async {
     try {
+      // Must include isDiscoverable — Firestore list rules require it.
       final snapshot = await docRef
+          .where('isDiscoverable', isEqualTo: true)
           .where(
             'boostExpiresAt',
             isGreaterThan: Timestamp.now(),

--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -17,12 +17,12 @@ class AppConfig {
   static const bool enablePushNotifications = true;
 
   // Social Media Links
-  static const String instagramUrl = 'https://instagram.com/naijasingles';
-  static const String twitterUrl = 'https://twitter.com/naijasingles';
-  static const String facebookUrl = 'https://facebook.com/naijasingles';
+  static const String instagramUrl = 'https://instagram.com/afropeep';
+  static const String twitterUrl = 'https://twitter.com/afropeep';
+  static const String facebookUrl = 'https://facebook.com/afropeep';
 
   // Support
-  static const String supportEmail = 'support@naijasingles.com';
+  static const String supportEmail = 'support@afropeep.com';
   static const String privacyPolicyUrl = 'https://afropeep.com/privacy';
   static const String termsOfServiceUrl = 'https://afropeep.com/terms';
 
@@ -71,7 +71,7 @@ String get googleMapsPlacesHttpKey {
 }
 
 //for support to user add you mail
-const adminMail = 'support@naijasingles.com';
+const adminMail = 'support@afropeep.com';
 // add bucket id from firebase or google-services-json
 String get bucketId => SecureConfig.firebaseStorageBucket;
 //for pagination set limit

--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -23,12 +23,12 @@ class AppConfig {
 
   // Support
   static const String supportEmail = 'support@naijasingles.com';
-  static const String privacyPolicyUrl = 'https://naijasingles.com/privacy';
-  static const String termsOfServiceUrl = 'https://naijasingles.com/terms';
+  static const String privacyPolicyUrl = 'https://afropeep.com/privacy';
+  static const String termsOfServiceUrl = 'https://afropeep.com/terms';
 
   /// Community guidelines (settings / safety).
   static const String communityGuidelinesUrl =
-      'https://naijasingles.com/community-guidelines';
+      'https://afropeep.com/community-guidelines';
 
   /// Android `applicationId` (Google Play) — must match Play Console for receipt checks.
   static const String androidApplicationId = 'com.app.naijasingles';
@@ -42,8 +42,8 @@ class AppConfig {
 }
 
 // Privacy policy and terms URLs
-const String termConditionUrl = 'https://naijasingles.com/terms';
-const String privacyUrl = 'https://naijasingles.com/privacy';
+const String termConditionUrl = 'https://afropeep.com/terms';
+const String privacyUrl = 'https://afropeep.com/privacy';
 
 // Add google map key for google places search
 String get googleMapsKey {

--- a/lib/features/payment/presentation/bloc/subscription_bloc.dart
+++ b/lib/features/payment/presentation/bloc/subscription_bloc.dart
@@ -375,6 +375,12 @@ class SubscriptionBloc extends Bloc<SubscriptionEvent, SubscriptionState> {
         continue;
       }
 
+      // Profile boost is a separate consumable — never treat it as Premium.
+      if (InAppPurchaseRepoImpl.isBoostProductId(purchase.productID)) {
+        _processedKeys.add(key);
+        continue;
+      }
+
       _processedKeys.add(key);
       emit(state.copyWith(purchaseInProgress: true));
 

--- a/lib/features/payment/presentation/bloc/subscription_bloc.dart
+++ b/lib/features/payment/presentation/bloc/subscription_bloc.dart
@@ -342,6 +342,13 @@ class SubscriptionBloc extends Bloc<SubscriptionEvent, SubscriptionState> {
           '${purchase.purchaseID ?? ""}|${purchase.productID}|${purchase.status.name}';
       if (_processedKeys.contains(key)) continue;
 
+      // Profile boost is handled by ProfileBoostPurchaseService, including
+      // pending and terminal updates. Never expose it as Premium progress.
+      if (InAppPurchaseRepoImpl.isBoostProductId(purchase.productID)) {
+        _processedKeys.add(key);
+        continue;
+      }
+
       if (purchase.status == PurchaseStatus.pending) {
         emit(state.copyWith(purchaseInProgress: true));
         continue;
@@ -372,12 +379,6 @@ class SubscriptionBloc extends Bloc<SubscriptionEvent, SubscriptionState> {
 
       if (purchase.status != PurchaseStatus.purchased &&
           purchase.status != PurchaseStatus.restored) {
-        continue;
-      }
-
-      // Profile boost is a separate consumable — never treat it as Premium.
-      if (InAppPurchaseRepoImpl.isBoostProductId(purchase.productID)) {
-        _processedKeys.add(key);
         continue;
       }
 

--- a/lib/features/profile/widgets/profile_boost_banner.dart
+++ b/lib/features/profile/widgets/profile_boost_banner.dart
@@ -39,6 +39,8 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
       widget._purchaseService ?? ProfileBoostPurchaseService();
 
   StreamSubscription<List<PurchaseDetails>>? _purchaseSub;
+  Timer? _countdownTimer;
+  DateTime? _expiresAtCached;
   Duration? _remaining;
   bool _loading = true;
   bool _purchasing = false;
@@ -48,6 +50,30 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
     super.initState();
     unawaited(_refresh());
     _listenForPurchases();
+  }
+
+  void _startCountdownTicker() {
+    _countdownTimer?.cancel();
+    if (_expiresAtCached == null) return;
+
+    _countdownTimer = Timer.periodic(const Duration(seconds: 1), (_) {
+      final expires = _expiresAtCached;
+      if (expires == null) return;
+
+      final live = expires.difference(DateTime.now());
+      if (!mounted) return;
+
+      if (live.isNegative) {
+        setState(() {
+          _remaining = null;
+          _expiresAtCached = null;
+        });
+        _countdownTimer?.cancel();
+        return;
+      }
+
+      setState(() => _remaining = live);
+    });
   }
 
   void _listenForPurchases() {
@@ -82,6 +108,7 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
 
   @override
   void dispose() {
+    _countdownTimer?.cancel();
     unawaited(_purchaseSub?.cancel());
     super.dispose();
   }
@@ -93,11 +120,18 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
       return;
     }
     final remaining = await _boostService.boostTimeRemaining(uid);
+    final expiresAt = await _boostService.boostExpiresAt(uid);
     if (!mounted) return;
     setState(() {
       _remaining = remaining;
+      _expiresAtCached = expiresAt;
       _loading = false;
     });
+    if (expiresAt != null && remaining != null) {
+      _startCountdownTicker();
+    } else {
+      _countdownTimer?.cancel();
+    }
   }
 
   Future<void> _purchaseBoost() async {
@@ -106,15 +140,18 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
 
     setState(() => _purchasing = true);
     try {
+      final productIds = await _purchaseService.fetchBoostProductIds();
       final products = await _purchaseService.fetchBoostProducts();
       if (!mounted) return;
 
       if (products.isEmpty) {
         setState(() => _purchasing = false);
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
+          SnackBar(
             content: Text(
-              'Boost is not available right now. Configure a boost package in the store.',
+              productIds.isEmpty
+                  ? 'Boost is not configured yet. Add a Packages doc with packageType boost.'
+                  : 'Boost product ${productIds.first} is not available from the App Store. Create it in App Store Connect (consumable).',
             ),
           ),
         );
@@ -132,7 +169,7 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
     }
   }
 
-  void _openProducts() {
+  void _openPremiumPlans() {
     unawaited(
       Navigator.of(context).push(
         MaterialPageRoute<void>(
@@ -144,6 +181,37 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
             child: Products(widget.currentUser, null, const {}),
           ),
         ),
+      ),
+    );
+  }
+
+  void _showBoostInfo() {
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(
+          'Profile Boost',
+          style: GoogleFonts.montserrat(fontWeight: FontWeight.w700),
+        ),
+        content: Text(
+          'Boost is a one-time purchase (not Premium). '
+          'It puts you higher in Connect for 1 hour. '
+          'Monthly Premium is a separate subscription.',
+          style: GoogleFonts.montserrat(fontSize: 14, height: 1.4),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('Got it'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(ctx).pop();
+              _openPremiumPlans();
+            },
+            child: const Text('View Premium'),
+          ),
+        ],
       ),
     );
   }
@@ -229,20 +297,12 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
           ),
           const SizedBox(width: 10),
           if (active)
-            TextButton(
-              onPressed: _openProducts,
-              style: TextButton.styleFrom(
-                foregroundColor: AppColors.primaryGreen,
-                padding: const EdgeInsets.symmetric(horizontal: 8),
-                minimumSize: const Size(0, 36),
-                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              ),
-              child: Text(
-                'Plans',
-                style: GoogleFonts.montserrat(
-                  fontSize: 13,
-                  fontWeight: FontWeight.w700,
-                ),
+            Text(
+              'Active',
+              style: GoogleFonts.montserrat(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                color: AppColors.primaryGreen,
               ),
             )
           else
@@ -277,8 +337,8 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
             ),
           if (!active)
             IconButton(
-              onPressed: _openProducts,
-              tooltip: 'View plans',
+              onPressed: _showBoostInfo,
+              tooltip: 'About boost',
               visualDensity: VisualDensity.compact,
               icon: const Icon(
                 Icons.info_outline_rounded,
@@ -292,9 +352,12 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
   }
 
   String _formatRemaining(Duration d) {
-    final minutes = d.inMinutes.remainder(60);
     final hours = d.inHours;
-    if (hours > 0) return '${hours}h ${minutes}m';
-    return '${minutes}m';
+    final minutes = d.inMinutes.remainder(60);
+    final seconds = d.inSeconds.remainder(60);
+    if (hours > 0) {
+      return '${hours}h ${minutes.toString().padLeft(2, '0')}m';
+    }
+    return '${minutes}m ${seconds.toString().padLeft(2, '0')}s';
   }
 }

--- a/lib/services/profile_boost_purchase_service.dart
+++ b/lib/services/profile_boost_purchase_service.dart
@@ -2,7 +2,8 @@ import 'dart:async';
 import 'dart:developer';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform, visibleForTesting;
 import 'package:in_app_purchase/in_app_purchase.dart';
 
 import '../common/constants/constants.dart';
@@ -71,6 +72,20 @@ class ProfileBoostPurchaseService {
     await _iap.buyConsumable(purchaseParam: param);
   }
 
+  /// Whether a store event should grant a new boost window.
+  ///
+  /// Consumable restores replay on every launch; only fresh `purchased`
+  /// (or unfinished restores that still need `completePurchase`) should activate.
+  @visibleForTesting
+  static bool shouldActivateFromPurchase(PurchaseDetails purchase) {
+    if (purchase.status == PurchaseStatus.purchased) return true;
+    if (purchase.status == PurchaseStatus.restored &&
+        purchase.pendingCompletePurchase) {
+      return true;
+    }
+    return false;
+  }
+
   /// Listens for a completed boost purchase and activates boost for [userId].
   StreamSubscription<List<PurchaseDetails>> listenForBoostActivation({
     required String userId,
@@ -83,6 +98,10 @@ class ProfileBoostPurchaseService {
             purchase.status == PurchaseStatus.restored) {
           final boostIds = await fetchBoostProductIds();
           if (!boostIds.contains(purchase.productID)) continue;
+
+          if (!shouldActivateFromPurchase(purchase)) {
+            continue;
+          }
 
           await _boostService.activateBoost(
             userId: userId,

--- a/lib/services/profile_boost_service.dart
+++ b/lib/services/profile_boost_service.dart
@@ -42,6 +42,20 @@ class ProfileBoostService {
     }
   }
 
+  /// Absolute boost expiry, or null if inactive / missing.
+  Future<DateTime?> boostExpiresAt(String userId) async {
+    try {
+      final doc = await _users.doc(userId).get();
+      final expiresAt = doc.data()?['boostExpiresAt'];
+      if (expiresAt is! Timestamp) return null;
+      final date = expiresAt.toDate();
+      return date.isAfter(DateTime.now()) ? date : null;
+    } on Object catch (e) {
+      debugPrint('ProfileBoostService.boostExpiresAt error: $e');
+      return null;
+    }
+  }
+
   /// Activates boost after successful IAP consumable purchase.
   Future<void> activateBoost({
     required String userId,

--- a/test/features/payment/subscription_bloc_test.dart
+++ b/test/features/payment/subscription_bloc_test.dart
@@ -194,6 +194,43 @@ void main() {
     );
   });
 
+  group('SubscriptionBloc boost purchases', () {
+    blocTest<SubscriptionBloc, SubscriptionState>(
+      'ignores pending and purchased boost updates',
+      build: buildBloc,
+      act: (SubscriptionBloc bloc) async {
+        bloc.add(const SubscriptionUserChanged('user-a'));
+        await Future<void>.delayed(Duration.zero);
+        bloc
+          ..add(
+            SubscriptionPurchaseBatch([
+              _purchase(
+                productId: 'com.afropeep.boost.1h',
+                status: PurchaseStatus.pending,
+              ),
+            ]),
+          )
+          ..add(
+            SubscriptionPurchaseBatch([
+              _purchase(productId: 'com.afropeep.boost.1h'),
+            ]),
+          );
+      },
+      expect: () => <SubscriptionState>[],
+      verify: (_) {
+        verifyNever(
+          () => functions.verifySubscriptionPurchase(
+            platform: any(named: 'platform'),
+            productId: any(named: 'productId'),
+            purchaseToken: any(named: 'purchaseToken'),
+            receiptData: any(named: 'receiptData'),
+            packageName: any(named: 'packageName'),
+          ),
+        );
+      },
+    );
+  });
+
   group('SubscriptionBloc consume events', () {
     blocTest<SubscriptionBloc, SubscriptionState>(
       'consume user message clears it',

--- a/test/services/profile_boost_purchase_service_test.dart
+++ b/test/services/profile_boost_purchase_service_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:in_app_purchase/in_app_purchase.dart';
+import 'package:naijasingles/services/profile_boost_purchase_service.dart';
+
+void main() {
+  PurchaseDetails details({
+    required PurchaseStatus status,
+    bool pendingComplete = false,
+  }) {
+    return PurchaseDetails(
+      productID: 'com.afropeep.boost.1h',
+      purchaseID: 'test',
+      verificationData: PurchaseVerificationData(
+        localVerificationData: '',
+        serverVerificationData: '',
+        source: 'test',
+      ),
+      transactionDate: null,
+      status: status,
+    )..pendingCompletePurchase = pendingComplete;
+  }
+
+  group('shouldActivateFromPurchase', () {
+    test('activates on purchased', () {
+      expect(
+        ProfileBoostPurchaseService.shouldActivateFromPurchase(
+          details(status: PurchaseStatus.purchased),
+        ),
+        isTrue,
+      );
+    });
+
+    test('skips completed restored consumables (no free re-boost)', () {
+      expect(
+        ProfileBoostPurchaseService.shouldActivateFromPurchase(
+          details(status: PurchaseStatus.restored),
+        ),
+        isFalse,
+      );
+    });
+
+    test('activates unfinished restored that still need completePurchase', () {
+      expect(
+        ProfileBoostPurchaseService.shouldActivateFromPurchase(
+          details(
+            status: PurchaseStatus.restored,
+            pendingComplete: true,
+          ),
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/web/community-guidelines/index.html
+++ b/web/community-guidelines/index.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Community Guidelines – Afropeep</title>
+  <meta name="description" content="Afropeep Community Guidelines: how we keep the community safe, respectful, and authentic.">
+  <meta name="robots" content="index,follow">
+  <link rel="canonical" href="https://afropeep.com/community-guidelines">
+  <link rel="icon" type="image/png" href="/favicon.png">
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --primary-green: #008037;
+      --text-primary: #2D2D2D;
+      --text-secondary: #666666;
+      --border: rgba(0, 128, 55, 0.12);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: 'Montserrat', sans-serif;
+      color: var(--text-primary);
+      background: #fff;
+      line-height: 1.65;
+    }
+    header {
+      border-bottom: 1px solid var(--border);
+      padding: 1rem 1.5rem;
+      position: sticky;
+      top: 0;
+      background: #fff;
+      z-index: 10;
+    }
+    header a {
+      color: var(--primary-green);
+      text-decoration: none;
+      font-weight: 700;
+      font-size: 1.1rem;
+    }
+    main {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 4rem;
+    }
+    h1 {
+      font-size: 1.75rem;
+      margin-bottom: 0.5rem;
+      color: var(--primary-green);
+    }
+    .meta {
+      color: var(--text-secondary);
+      font-size: 0.95rem;
+      margin-bottom: 2rem;
+    }
+    h2 {
+      font-size: 1.15rem;
+      margin: 1.75rem 0 0.6rem;
+    }
+    p, li { color: var(--text-secondary); margin-bottom: 0.75rem; }
+    ul { padding-left: 1.25rem; margin-bottom: 1rem; }
+    a { color: var(--primary-green); }
+    footer {
+      border-top: 1px solid var(--border);
+      padding: 1.5rem;
+      text-align: center;
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <a href="/">← Afropeep</a>
+  </header>
+  <main>
+    <h1>Community Guidelines</h1>
+    <p class="meta">
+      Effective date: July 24, 2026<br>
+      Contact: <a href="mailto:support@afropeep.com">support@afropeep.com</a>
+    </p>
+
+    <p>
+      Afropeep is for adults in the African diaspora who want respectful dating, friendship,
+      networking, and community. These guidelines work together with our
+      <a href="/terms">Terms of Service</a> and <a href="/privacy">Privacy Policy</a>.
+      Violations may lead to content removal, account suspension, or permanent bans.
+    </p>
+
+    <h2>1. Be 18+</h2>
+    <p>
+      You must be at least 18 years old. Accounts for minors are not allowed. Report any
+      suspected underage users immediately.
+    </p>
+
+    <h2>2. Be respectful</h2>
+    <p>Treat others with dignity. Do not:</p>
+    <ul>
+      <li>Harass, threaten, stalk, or bully anyone</li>
+      <li>Use hate speech or discriminate based on race, ethnicity, nationality, religion, gender, sexual orientation, disability, or similar characteristics</li>
+      <li>Sexually harass, share non-consensual intimate imagery, or pressure others for sexual content</li>
+      <li>Impersonate another person or misrepresent who you are</li>
+    </ul>
+
+    <h2>3. Be authentic</h2>
+    <ul>
+      <li>Use recent photos that are clearly of you</li>
+      <li>Do not use celebrity, stolen, heavily misleading, or AI-generated fake profile photos as if they are you</li>
+      <li>Keep bio and profile details truthful enough that others are not deceived</li>
+    </ul>
+
+    <h2>4. No scams or spam</h2>
+    <ul>
+      <li>Do not solicit money, gifts, investment schemes, or “send crypto” pitches</li>
+      <li>Do not run commercial spam, mass outreach, or phishing</li>
+      <li>Do not promote illegal goods or services</li>
+    </ul>
+
+    <h2>5. Keep chats and content appropriate</h2>
+    <ul>
+      <li>No illegal content; no content involving minors in any sexual context</li>
+      <li>No graphic violence or content intended primarily to shock or harm</li>
+      <li>Respect boundaries—if someone declines contact, stop</li>
+    </ul>
+
+    <h2>6. Meet safely</h2>
+    <p>
+      Afropeep helps people connect; we do not guarantee anyone’s identity or intentions.
+      Prefer public places for first meetings, tell a friend where you are going, and never share
+      financial information with matches.
+    </p>
+
+    <h2>7. Reporting and enforcement</h2>
+    <p>
+      Use in-app reporting tools when someone violates these guidelines. We may remove content,
+      warn users, or suspend or ban accounts. Serious or illegal activity may be reported to
+      authorities when appropriate.
+    </p>
+    <p>
+      Questions or appeals:
+      <a href="mailto:support@afropeep.com">support@afropeep.com</a>
+    </p>
+  </main>
+  <footer>
+    <p>© 2026 Afropeep. All rights reserved.</p>
+    <p>
+      <a href="/">Home</a> ·
+      <a href="/privacy">Privacy Policy</a> ·
+      <a href="/terms">Terms of Service</a> ·
+      <a href="/community-guidelines">Community Guidelines</a>
+    </p>
+  </footer>
+</body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -997,8 +997,8 @@
                 Want early access? Email us at <a href="mailto:support@afropeep.com?subject=Waitlist">support@afropeep.com</a>.
             </p>
             <div class="footer-links">
-                <a href="mailto:support@afropeep.com?subject=Privacy%20Policy">Privacy Policy</a>
-                <a href="mailto:support@afropeep.com?subject=Terms%20of%20Service">Terms of Service</a>
+                <a href="/privacy">Privacy Policy</a>
+                <a href="/terms">Terms of Service</a>
                 <a href="mailto:support@afropeep.com">Support</a>
             </div>
             

--- a/web/index.html
+++ b/web/index.html
@@ -2,21 +2,21 @@
     <base href="$FLUTTER_BASE_HREF">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Afropeep – Join the waitlist</title>
-    <meta name="description" content="Afropeep is coming soon. Dating, friendship, and community for the African diaspora. Join the waitlist for early access.">
+    <title>Afropeep – Dating, friendship &amp; community for the African diaspora</title>
+    <meta name="description" content="Afropeep connects Africans in the diaspora through dating, friendship, networking, and local community. Join the early-access waitlist.">
     <meta name="keywords" content="Afropeep, African dating, diaspora, waitlist, dating app, community">
     
     <!-- Open Graph Meta Tags -->
-    <meta property="og:title" content="Afropeep – Join the waitlist">
-    <meta property="og:description" content="App coming soon. Dating, friendship, and community for the African diaspora. Join the waitlist for early access.">
+    <meta property="og:title" content="Afropeep – Dating, friendship &amp; community for the African diaspora">
+    <meta property="og:description" content="Connect with Africans near you through dating, friendship, networking, and community. Join early access.">
     <meta property="og:image" content="https://afropeep.com/hero-couple.jpg">
     <meta property="og:url" content="https://afropeep.com">
     <meta property="og:type" content="website">
     
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Afropeep – Join the waitlist">
-    <meta name="twitter:description" content="App coming soon. Join the waitlist for early access.">
+    <meta name="twitter:title" content="Afropeep – Dating, friendship &amp; community for the African diaspora">
+    <meta name="twitter:description" content="Connect with Africans near you. Join early access.">
     <meta name="twitter:image" content="https://afropeep.com/hero-couple.jpg">
     
     <!-- Favicon -->
@@ -859,7 +859,7 @@
         <div class="hero-content">
             <h1 class="hero-wordmark">Afropeep</h1>
             <div class="hero-spacer"></div>
-            <p class="hero-tagline">App coming soon. Join the waitlist for early access.</p>
+            <p class="hero-tagline">Dating, friendship, and community for the African diaspora. Join early access.</p>
             <div class="hero-cta-wrap">
                 <a href="#contact" class="download-btn waitlist-cta">Join waitlist</a>
             </div>
@@ -999,11 +999,12 @@
             <div class="footer-links">
                 <a href="/privacy">Privacy Policy</a>
                 <a href="/terms">Terms of Service</a>
+                <a href="/community-guidelines">Community Guidelines</a>
                 <a href="mailto:support@afropeep.com">Support</a>
             </div>
             
             <div class="footer-bottom">
-                <p>© 2024 Afropeep. All rights reserved.</p>
+                <p>© 2026 Afropeep. All rights reserved.</p>
                 <p style="margin-top: 1rem;">
                     Made with <i class="fas fa-heart" style="color: var(--primary-green);"></i> for the African diaspora worldwide
                 </p>

--- a/web/privacy/index.html
+++ b/web/privacy/index.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy – Afropeep</title>
+  <meta name="description" content="Afropeep Privacy Policy: how we collect, use, and protect your information.">
+  <meta name="robots" content="index,follow">
+  <link rel="canonical" href="https://afropeep.com/privacy">
+  <link rel="icon" type="image/png" href="/favicon.png">
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --primary-green: #008037;
+      --text-primary: #2D2D2D;
+      --text-secondary: #666666;
+      --border: rgba(0, 128, 55, 0.12);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: 'Montserrat', sans-serif;
+      color: var(--text-primary);
+      background: #fff;
+      line-height: 1.65;
+    }
+    header {
+      border-bottom: 1px solid var(--border);
+      padding: 1rem 1.5rem;
+      position: sticky;
+      top: 0;
+      background: #fff;
+      z-index: 10;
+    }
+    header a {
+      color: var(--primary-green);
+      text-decoration: none;
+      font-weight: 700;
+      font-size: 1.1rem;
+    }
+    main {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 4rem;
+    }
+    h1 {
+      font-size: 1.75rem;
+      margin-bottom: 0.5rem;
+      color: var(--primary-green);
+    }
+    .meta {
+      color: var(--text-secondary);
+      font-size: 0.95rem;
+      margin-bottom: 2rem;
+    }
+    h2 {
+      font-size: 1.15rem;
+      margin: 1.75rem 0 0.6rem;
+    }
+    p, li { color: var(--text-secondary); margin-bottom: 0.75rem; }
+    ul { padding-left: 1.25rem; margin-bottom: 1rem; }
+    a { color: var(--primary-green); }
+    footer {
+      border-top: 1px solid var(--border);
+      padding: 1.5rem;
+      text-align: center;
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <a href="/">← Afropeep</a>
+  </header>
+  <main>
+    <h1>Privacy Policy</h1>
+    <p class="meta">
+      Effective date: July 24, 2026<br>
+      Contact: <a href="mailto:support@afropeep.com">support@afropeep.com</a>
+    </p>
+
+    <p>
+      Afropeep (“we,” “us,” or “our”) operates the Afropeep mobile application and related
+      services (the “Service”). This Privacy Policy explains what information we collect,
+      how we use it, and your choices.
+    </p>
+
+    <h2>1. Information we collect</h2>
+    <p><strong>Account and profile information</strong> you provide, such as name, email address,
+      phone number, date of birth, photos, bio, preferences, nationality/ethnicity, religion,
+      sexual orientation (if you choose to share it), and other profile details.</p>
+    <p><strong>Messages and user content</strong>, including chats, posts, event content, and
+      other material you create or share.</p>
+    <p><strong>Location data</strong>, if you grant permission, to show nearby people and events
+      and to power discovery features.</p>
+    <p><strong>Device and usage data</strong>, such as device identifiers, app interactions,
+      crash logs, and performance diagnostics (including via providers like Firebase).</p>
+    <p><strong>Purchase information</strong> related to in-app purchases (e.g. Premium or Profile
+      Boost). Payment card details are processed by Apple or Google; we do not receive your full
+      payment card number.</p>
+    <p><strong>Authentication data</strong> when you sign in with phone, email/password, Google,
+      Apple, or other providers. We receive identifiers needed to create and secure your account.
+      We do not receive your social-login password.</p>
+
+    <h2>2. How we use information</h2>
+    <p>We use information to:</p>
+    <ul>
+      <li>Provide, operate, personalize, and improve the Service</li>
+      <li>Authenticate users and secure accounts</li>
+      <li>Enable matching, messaging, communities, and events</li>
+      <li>Process purchases and entitlements</li>
+      <li>Moderate content and enforce our terms and safety policies</li>
+      <li>Communicate with you about the Service</li>
+      <li>Analyze usage and fix crashes</li>
+      <li>Comply with law and protect rights and safety</li>
+    </ul>
+    <p>We may use aggregated or de-identified data for analytics and product development.</p>
+
+    <h2>3. How we share information</h2>
+    <p>We do <strong>not sell</strong> your personal information.</p>
+    <p>We may share information with:</p>
+    <ul>
+      <li><strong>Other users</strong>, as part of the Service (e.g. profile visibility, messages you send)</li>
+      <li><strong>Service providers</strong> who help us operate the Service (hosting, analytics, crash reporting, authentication, cloud infrastructure), under appropriate agreements</li>
+      <li><strong>Authorities or others</strong> when required by law, or to protect rights, safety, or security</li>
+      <li><strong>A successor entity</strong> in connection with a merger, sale, or reorganization</li>
+    </ul>
+
+    <h2>4. Data retention</h2>
+    <p>
+      We retain information while your account is active and as needed to provide the Service and
+      meet legal obligations. When you delete your account, we delete or anonymize associated data
+      according to our retention practices, except where we must keep limited records
+      (e.g. fraud prevention, legal compliance).
+    </p>
+
+    <h2>5. Your choices and account deletion</h2>
+    <p>
+      You may update profile information in the app. You may delete your account in account
+      settings. You may control location and other permissions in device settings. For privacy
+      requests, email <a href="mailto:support@afropeep.com">support@afropeep.com</a>.
+    </p>
+
+    <h2>6. Security</h2>
+    <p>
+      We use industry-standard measures such as encryption in transit, access controls, and secure
+      authentication. No method of transmission or storage is 100% secure.
+    </p>
+
+    <h2>7. Children’s privacy</h2>
+    <p>
+      The Service is for adults (18+). We do not knowingly collect personal information from
+      children under 13 (or under 18 where required). If you believe a minor has provided data,
+      contact us and we will take appropriate steps.
+    </p>
+
+    <h2>8. International users</h2>
+    <p>
+      We may process information in the United States and other countries where we or our providers
+      operate. By using the Service, you understand your information may be transferred to those
+      locations.
+    </p>
+
+    <h2>9. Changes</h2>
+    <p>
+      We may update this Policy from time to time. We will post the updated version and revise the
+      effective date. Continued use of the Service after changes means you accept the updated Policy.
+    </p>
+
+    <h2>10. Contact</h2>
+    <p>
+      Privacy questions or requests:
+      <a href="mailto:support@afropeep.com">support@afropeep.com</a>
+    </p>
+  </main>
+  <footer>
+    <p>© 2026 Afropeep. All rights reserved.</p>
+    <p><a href="/">Home</a> · <a href="/privacy">Privacy Policy</a> · <a href="/terms">Terms of Service</a></p>
+  </footer>
+</body>
+</html>

--- a/web/privacy/index.html
+++ b/web/privacy/index.html
@@ -175,7 +175,12 @@
   </main>
   <footer>
     <p>© 2026 Afropeep. All rights reserved.</p>
-    <p><a href="/">Home</a> · <a href="/privacy">Privacy Policy</a> · <a href="/terms">Terms of Service</a></p>
+    <p>
+      <a href="/">Home</a> ·
+      <a href="/privacy">Privacy Policy</a> ·
+      <a href="/terms">Terms of Service</a> ·
+      <a href="/community-guidelines">Community Guidelines</a>
+    </p>
   </footer>
 </body>
 </html>

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://afropeep.com/sitemap.xml

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://afropeep.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://afropeep.com/privacy</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://afropeep.com/terms</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://afropeep.com/community-guidelines</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>

--- a/web/terms/index.html
+++ b/web/terms/index.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Terms of Service – Afropeep</title>
+  <meta name="description" content="Afropeep Terms of Service: rules for using the Afropeep app and related services.">
+  <meta name="robots" content="index,follow">
+  <link rel="canonical" href="https://afropeep.com/terms">
+  <link rel="icon" type="image/png" href="/favicon.png">
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --primary-green: #008037;
+      --text-primary: #2D2D2D;
+      --text-secondary: #666666;
+      --border: rgba(0, 128, 55, 0.12);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: 'Montserrat', sans-serif;
+      color: var(--text-primary);
+      background: #fff;
+      line-height: 1.65;
+    }
+    header {
+      border-bottom: 1px solid var(--border);
+      padding: 1rem 1.5rem;
+      position: sticky;
+      top: 0;
+      background: #fff;
+      z-index: 10;
+    }
+    header a {
+      color: var(--primary-green);
+      text-decoration: none;
+      font-weight: 700;
+      font-size: 1.1rem;
+    }
+    main {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 4rem;
+    }
+    h1 {
+      font-size: 1.75rem;
+      margin-bottom: 0.5rem;
+      color: var(--primary-green);
+    }
+    .meta {
+      color: var(--text-secondary);
+      font-size: 0.95rem;
+      margin-bottom: 2rem;
+    }
+    h2 {
+      font-size: 1.15rem;
+      margin: 1.75rem 0 0.6rem;
+    }
+    p, li { color: var(--text-secondary); margin-bottom: 0.75rem; }
+    ul { padding-left: 1.25rem; margin-bottom: 1rem; }
+    a { color: var(--primary-green); }
+    footer {
+      border-top: 1px solid var(--border);
+      padding: 1.5rem;
+      text-align: center;
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <a href="/">← Afropeep</a>
+  </header>
+  <main>
+    <h1>Terms of Service</h1>
+    <p class="meta">
+      Effective date: July 24, 2026<br>
+      Contact: <a href="mailto:support@afropeep.com">support@afropeep.com</a>
+    </p>
+
+    <p>
+      These Terms of Service (“Terms”) govern your access to and use of the Afropeep mobile
+      application and related services (the “Service”) operated by Afropeep (“we,” “us,” or “our”).
+      By creating an account or using the Service, you agree to these Terms and our
+      <a href="/privacy">Privacy Policy</a>. If you do not agree, do not use the Service.
+    </p>
+
+    <h2>1. Eligibility</h2>
+    <p>
+      You must be at least 18 years old and legally able to enter into a binding agreement to use
+      this Service. By using Afropeep, you represent that you meet these requirements. The Service
+      is intended for adults seeking dating, friendship, networking, or community connections.
+    </p>
+
+    <h2>2. Account responsibilities</h2>
+    <p>
+      You are responsible for maintaining the confidentiality of your account credentials and for
+      all activity under your account. You must provide accurate information and keep it up to date.
+      You may not share your account, impersonate others, or create accounts for anyone other than
+      yourself without permission.
+    </p>
+
+    <h2>3. License to use the Service</h2>
+    <p>
+      We grant you a limited, non-exclusive, non-transferable, revocable license to use the Service
+      for personal, non-commercial purposes in accordance with these Terms. We reserve all rights
+      not expressly granted.
+    </p>
+
+    <h2>4. Community behavior</h2>
+    <p>You agree to treat other users with respect and to comply with our community guidelines. You may not:</p>
+    <ul>
+      <li>Harass, threaten, stalk, or abuse others</li>
+      <li>Use hate speech or discriminate based on protected characteristics</li>
+      <li>Impersonate any person or entity</li>
+      <li>Solicit money, promote scams, or engage in fraud</li>
+      <li>Share illegal, sexual involving minors, or otherwise prohibited content</li>
+      <li>Spam, scrape, or reverse engineer the Service</li>
+      <li>Interfere with the safety, security, or operation of the Service</li>
+    </ul>
+    <p>Violations may result in warnings, suspension, or permanent removal.</p>
+
+    <h2>5. Content and messaging</h2>
+    <p>
+      You retain ownership of content you post (photos, bio, messages, posts, and similar materials).
+      You grant Afropeep a worldwide, non-exclusive, royalty-free license to host, use, display,
+      reproduce, and distribute your content as needed to operate and improve the Service.
+    </p>
+    <p>
+      You are solely responsible for the content you share and must have the rights to post it.
+      Do not post illegal, infringing, or non-consensual material. We may remove content and take
+      action on accounts that violate these Terms or our policies.
+    </p>
+
+    <h2>6. Safety and interactions with others</h2>
+    <p>
+      Afropeep helps people connect; we do not conduct criminal background checks on all users and
+      do not guarantee the identity, conduct, or compatibility of any user. Use caution when meeting
+      offline. You are solely responsible for your interactions with other users.
+    </p>
+
+    <h2>7. Payments, subscriptions, and boosts</h2>
+    <p>
+      Some features may require payment, including subscriptions (e.g. Afropeep Premium) and
+      one-time consumable purchases (e.g. Profile Boost). Purchases are processed by Apple App Store
+      or Google Play under their terms. Pricing and availability may vary by platform and region.
+    </p>
+    <p>
+      Subscriptions renew automatically unless canceled according to the store’s instructions.
+      Consumable purchases (such as Boost) provide a time-limited benefit as described in the app
+      and do not auto-renew. Refunds are handled by Apple or Google according to their policies and
+      applicable law; we do not control store refund decisions.
+    </p>
+
+    <h2>8. Intellectual property</h2>
+    <p>
+      The Service, including branding, design, software, and trademarks, is owned by Afropeep or
+      its licensors. You may not copy, modify, distribute, or create derivative works from our
+      materials except as allowed by these Terms or with our prior written consent.
+    </p>
+
+    <h2>9. Account suspension or removal</h2>
+    <p>
+      We may suspend or terminate your account if you breach these Terms, violate our policies,
+      create risk or legal exposure for us or others, or for other operational or legal reasons.
+      You may delete your account at any time through account settings.
+    </p>
+
+    <h2>10. Disclaimers</h2>
+    <p>
+      THE SERVICE IS PROVIDED “AS IS” AND “AS AVAILABLE.” TO THE MAXIMUM EXTENT PERMITTED BY LAW,
+      WE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING MERCHANTABILITY, FITNESS FOR A
+      PARTICULAR PURPOSE, AND NON-INFRINGEMENT. WE DO NOT WARRANT THAT THE SERVICE WILL BE
+      UNINTERRUPTED, ERROR-FREE, OR COMPLETELY SECURE.
+    </p>
+
+    <h2>11. Limitation of liability</h2>
+    <p>
+      TO THE MAXIMUM EXTENT PERMITTED BY LAW, AFROPEEP AND ITS AFFILIATES, OFFICERS, EMPLOYEES,
+      AND AGENTS WILL NOT BE LIABLE FOR INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE
+      DAMAGES, OR ANY LOSS OF PROFITS, DATA, OR GOODWILL, ARISING FROM YOUR USE OF THE SERVICE.
+      OUR TOTAL LIABILITY FOR ANY CLAIM RELATING TO THE SERVICE WILL NOT EXCEED THE GREATER OF
+      (A) THE AMOUNTS YOU PAID US FOR THE SERVICE IN THE 12 MONTHS BEFORE THE CLAIM OR (B) USD $100.
+    </p>
+
+    <h2>12. Indemnity</h2>
+    <p>
+      You agree to indemnify and hold harmless Afropeep and its affiliates from claims, damages,
+      losses, and expenses (including reasonable attorneys’ fees) arising from your content, your
+      use of the Service, or your violation of these Terms or applicable law.
+    </p>
+
+    <h2>13. Changes to the Service or Terms</h2>
+    <p>
+      We may modify the Service or these Terms from time to time. We will post updated Terms and
+      revise the effective date. Continued use after changes means you accept the updated Terms.
+      If you do not agree, stop using the Service and delete your account.
+    </p>
+
+    <h2>14. Governing law</h2>
+    <p>
+      These Terms are governed by the laws of the United States and the State of Texas, excluding
+      conflict-of-law rules, unless mandatory consumer protections in your place of residence
+      provide otherwise. Courts in Texas will have exclusive jurisdiction, subject to applicable
+      consumer rights.
+    </p>
+
+    <h2>15. Contact</h2>
+    <p>
+      Questions about these Terms:
+      <a href="mailto:support@afropeep.com">support@afropeep.com</a>
+    </p>
+  </main>
+  <footer>
+    <p>© 2026 Afropeep. All rights reserved.</p>
+    <p><a href="/">Home</a> · <a href="/privacy">Privacy Policy</a> · <a href="/terms">Terms of Service</a></p>
+  </footer>
+</body>
+</html>

--- a/web/terms/index.html
+++ b/web/terms/index.html
@@ -214,7 +214,12 @@
   </main>
   <footer>
     <p>© 2026 Afropeep. All rights reserved.</p>
-    <p><a href="/">Home</a> · <a href="/privacy">Privacy Policy</a> · <a href="/terms">Terms of Service</a></p>
+    <p>
+      <a href="/">Home</a> ·
+      <a href="/privacy">Privacy Policy</a> ·
+      <a href="/terms">Terms of Service</a> ·
+      <a href="/community-guidelines">Community Guidelines</a>
+    </p>
   </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Fix Profile Boost so completed StoreKit restores no longer re-grant a full 1-hour window, and the banner countdown ticks from `boostExpiresAt`.
- Keep boost consumables out of Premium subscription verification; require `isDiscoverable` on the boost discovery query (plus composite index).
- Publish afropeep.com Privacy, Terms, and Community Guidelines (plus robots/sitemap), and point app support/social config at `support@afropeep.com` / afropeep handles.

## Test plan
- [ ] Buy or activate boost (sandbox/StoreKit): banner shows live countdown (`Mm Ss`), not a frozen hour
- [ ] Relaunch app with a prior boost restore: console/behavior should not reset expiry to a fresh 1h
- [ ] Confirm Premium purchase/restore still verifies; boost SKUs are skipped by `SubscriptionBloc`
- [ ] Connect discovery still loads (boosted users query no longer permission-denied when discoverable)
- [ ] Open https://afropeep.com/privacy, /terms, /community-guidelines, /robots.txt, /sitemap.xml
- [ ] In-app support/mailto and settings guidelines URL use afropeep.com / support@afropeep.com


Made with [Cursor](https://cursor.com)