### PR TITLE
fix(boost): activate in-flight StoreKit restored purchases

### DIFF
--- a/lib/features/profile/widgets/profile_boost_banner.dart
+++ b/lib/features/profile/widgets/profile_boost_banner.dart
@@ -38,8 +38,11 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
   late final ProfileBoostPurchaseService _purchaseService =
       widget._purchaseService ?? ProfileBoostPurchaseService();
 
+  static const Duration _purchaseTimeout = Duration(seconds: 90);
+
   StreamSubscription<List<PurchaseDetails>>? _purchaseSub;
   Timer? _countdownTimer;
+  Timer? _purchaseTimeoutTimer;
   DateTime? _expiresAtCached;
   Duration? _remaining;
   bool _loading = true;
@@ -76,6 +79,30 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
     });
   }
 
+  void _clearPurchasing() {
+    _purchaseTimeoutTimer?.cancel();
+    _purchaseTimeoutTimer = null;
+    if (!mounted) return;
+    if (_purchasing) {
+      setState(() => _purchasing = false);
+    }
+  }
+
+  void _startPurchaseTimeout() {
+    _purchaseTimeoutTimer?.cancel();
+    _purchaseTimeoutTimer = Timer(_purchaseTimeout, () {
+      if (!mounted || !_purchasing) return;
+      _clearPurchasing();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Boost purchase timed out. Please try again.',
+          ),
+        ),
+      );
+    });
+  }
+
   void _listenForPurchases() {
     final uid = widget.currentUser.id ?? FirebaseAuth.instance.currentUser?.uid;
     if (uid == null) return;
@@ -84,7 +111,7 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
       userId: uid,
       onActivated: () {
         if (!mounted) return;
-        setState(() => _purchasing = false);
+        _clearPurchasing();
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
@@ -96,9 +123,12 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
         );
         unawaited(_refresh());
       },
+      onCanceled: () {
+        _clearPurchasing();
+      },
       onError: (message) {
         if (!mounted) return;
-        setState(() => _purchasing = false);
+        _clearPurchasing();
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(message), backgroundColor: AppColors.error),
         );
@@ -109,6 +139,7 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
   @override
   void dispose() {
     _countdownTimer?.cancel();
+    _purchaseTimeoutTimer?.cancel();
     unawaited(_purchaseSub?.cancel());
     super.dispose();
   }
@@ -139,19 +170,37 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
     if (uid == null || _purchasing) return;
 
     setState(() => _purchasing = true);
+    _startPurchaseTimeout();
     try {
+      final storeAvailable = await _purchaseService.isStoreAvailable();
+      if (!mounted) return;
+      if (!storeAvailable) {
+        _clearPurchasing();
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'App Store is unavailable. Check your network connection and try again.',
+            ),
+          ),
+        );
+        return;
+      }
+
       final productIds = await _purchaseService.fetchBoostProductIds();
       final products = await _purchaseService.fetchBoostProducts();
       if (!mounted) return;
 
       if (products.isEmpty) {
-        setState(() => _purchasing = false);
+        _clearPurchasing();
+        final nonEmptyIds =
+            productIds.where((id) => id.trim().isNotEmpty).toList();
+        final configuredId = nonEmptyIds.isEmpty ? null : nonEmptyIds.first;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
-              productIds.isEmpty
+              configuredId == null
                   ? 'Boost is not configured yet. Add a Packages doc with packageType boost.'
-                  : 'Boost product ${productIds.first} is not available from the App Store. Create it in App Store Connect (consumable).',
+                  : 'Boost product $configuredId is not available from the App Store. Create it in App Store Connect (consumable).',
             ),
           ),
         );
@@ -161,7 +210,7 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
       await _purchaseService.buyBoost(products.first);
     } on Object catch (e) {
       if (mounted) {
-        setState(() => _purchasing = false);
+        _clearPurchasing();
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Could not start purchase: $e')),
         );

--- a/lib/features/profile/widgets/profile_boost_banner.dart
+++ b/lib/features/profile/widgets/profile_boost_banner.dart
@@ -82,6 +82,7 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
   void _clearPurchasing() {
     _purchaseTimeoutTimer?.cancel();
     _purchaseTimeoutTimer = null;
+    _purchaseService.clearAwaitingBoostPurchase();
     if (!mounted) return;
     if (_purchasing) {
       setState(() => _purchasing = false);

--- a/lib/services/profile_boost_purchase_service.dart
+++ b/lib/services/profile_boost_purchase_service.dart
@@ -15,38 +15,91 @@ class ProfileBoostPurchaseService {
     InAppPurchase? iap,
     ProfileBoostService? boostService,
     FirebaseFirestore? firestore,
+    Future<List<String>> Function()? boostProductIds,
   })  : _iap = iap ?? InAppPurchase.instance,
         _boostService = boostService ?? ProfileBoostService(),
-        _firestore = firestore ?? firebaseFireStoreInstance;
+        _firestore = firestore ?? firebaseFireStoreInstance,
+        _boostProductIdsOverride = boostProductIds;
 
   final InAppPurchase _iap;
   final ProfileBoostService _boostService;
   final FirebaseFirestore _firestore;
+  final Future<List<String>> Function()? _boostProductIdsOverride;
+
+  /// Product ID for an in-flight [buyBoost] call.
+  ///
+  /// StoreKit (esp. sandbox) often emits `restored` + `pendingComplete=false`
+  /// for a user-initiated consumable buy. We only activate those while this is set,
+  /// so cold-start restore replays still do not re-grant boost.
+  String? _awaitingBoostProductId;
 
   static const String _packageTypeBoost = 'boost';
 
+  /// Picks a non-empty store SKU from a Packages doc for [platform].
+  ///
+  /// Empty `iosProductId` / `androidProductId` must not block a valid legacy
+  /// `id` — Firestore often stores `""` for the unused platform field.
+  @visibleForTesting
+  static String? resolveBoostProductId(
+    Map<String, dynamic> data, {
+    required TargetPlatform platform,
+  }) {
+    String? nonEmpty(Object? raw) {
+      final value = raw?.toString().trim();
+      if (value == null || value.isEmpty) return null;
+      return value;
+    }
+
+    final legacy = nonEmpty(data['id']);
+    final ios = nonEmpty(data['iosProductId']);
+    final android = nonEmpty(data['androidProductId']);
+
+    String? fromStoreIds;
+    final storeIds = data['storeIds'];
+    if (storeIds is Map) {
+      if (platform == TargetPlatform.iOS) {
+        fromStoreIds = nonEmpty(storeIds['ios']) ?? nonEmpty(storeIds['apple']);
+      } else if (platform == TargetPlatform.android) {
+        fromStoreIds =
+            nonEmpty(storeIds['android']) ?? nonEmpty(storeIds['play']);
+      }
+    }
+
+    if (platform == TargetPlatform.iOS) {
+      return fromStoreIds ?? ios ?? legacy;
+    }
+    if (platform == TargetPlatform.android) {
+      return fromStoreIds ?? android ?? legacy;
+    }
+    return legacy;
+  }
+
   /// Store product IDs for boost packages (`Packages` docs with `packageType: boost`).
   Future<List<String>> fetchBoostProductIds() async {
+    final override = _boostProductIdsOverride;
+    if (override != null) return override();
+
     try {
+      // Query by status only (same as Premium Packages fetch) so we do not
+      // depend on a status+packageType composite index. Filter boost client-side.
       final snap = await _firestore
           .collection('Packages')
           .where('status', isEqualTo: true)
-          .where('packageType', isEqualTo: _packageTypeBoost)
           .get();
 
       final ids = <String>{};
       for (final doc in snap.docs) {
         final data = doc.data();
-        final legacy = data['id']?.toString();
-        final ios = data['iosProductId']?.toString();
-        final android = data['androidProductId']?.toString();
-        if (defaultTargetPlatform == TargetPlatform.iOS && ios != null) {
-          ids.add(ios);
-        } else if (defaultTargetPlatform == TargetPlatform.android &&
-            android != null) {
-          ids.add(android);
-        } else if (legacy != null && legacy.isNotEmpty) {
-          ids.add(legacy);
+        final packageType =
+            data['packageType']?.toString().toLowerCase().trim() ?? '';
+        if (packageType != _packageTypeBoost) continue;
+
+        final id = resolveBoostProductId(
+          data,
+          platform: defaultTargetPlatform,
+        );
+        if (id != null) {
+          ids.add(id);
         }
       }
       return ids.toList();
@@ -58,65 +111,148 @@ class ProfileBoostPurchaseService {
 
   Future<List<ProductDetails>> fetchBoostProducts() async {
     final available = await _iap.isAvailable();
-    if (!available) return [];
+    if (!available) {
+      log('ProfileBoostPurchaseService: store not available');
+      return [];
+    }
 
     final ids = await fetchBoostProductIds();
-    if (ids.isEmpty) return [];
+    final queryIds = ids.where((id) => id.isNotEmpty).toSet();
+    if (queryIds.isEmpty) {
+      log(
+        'ProfileBoostPurchaseService: no boost product IDs '
+        '(Packages docs=${ids.length})',
+      );
+      return [];
+    }
 
-    final response = await _iap.queryProductDetails(ids.toSet());
+    final response = await _iap.queryProductDetails(queryIds);
+    if (response.productDetails.isEmpty) {
+      log(
+        'ProfileBoostPurchaseService: store returned 0 products for $queryIds '
+        '(notFound=${response.notFoundIDs})',
+      );
+    }
     return response.productDetails;
   }
 
+  /// Whether the platform billing client is reachable.
+  Future<bool> isStoreAvailable() => _iap.isAvailable();
+
   Future<void> buyBoost(ProductDetails product) async {
+    _awaitingBoostProductId = product.id;
     final param = PurchaseParam(productDetails: product);
     await _iap.buyConsumable(purchaseParam: param);
   }
 
   /// Whether a store event should grant a new boost window.
   ///
-  /// Consumable restores replay on every launch; only fresh `purchased`
-  /// (or unfinished restores that still need `completePurchase`) should activate.
+  /// Consumable restores replay on every launch; only fresh `purchased`,
+  /// unfinished restores that still need `completePurchase`, or a `restored`
+  /// event that arrives while [awaitingUserPurchase] (in-flight [buyBoost])
+  /// should activate.
   @visibleForTesting
-  static bool shouldActivateFromPurchase(PurchaseDetails purchase) {
+  static bool shouldActivateFromPurchase(
+    PurchaseDetails purchase, {
+    bool awaitingUserPurchase = false,
+  }) {
     if (purchase.status == PurchaseStatus.purchased) return true;
     if (purchase.status == PurchaseStatus.restored &&
         purchase.pendingCompletePurchase) {
       return true;
     }
+    if (purchase.status == PurchaseStatus.restored && awaitingUserPurchase) {
+      return true;
+    }
     return false;
   }
 
+  /// Handles one store update for boost (activation, cancel, or error).
+  @visibleForTesting
+  Future<void> handlePurchaseUpdate({
+    required PurchaseDetails purchase,
+    required String userId,
+    required void Function() onActivated,
+    void Function()? onCanceled,
+    void Function(String message)? onError,
+  }) async {
+    try {
+      final boostIds = await fetchBoostProductIds();
+      final bool awaitingUserPurchase = _awaitingBoostProductId != null &&
+          _awaitingBoostProductId == purchase.productID;
+      if (!boostIds.contains(purchase.productID)) return;
+
+      if (purchase.status == PurchaseStatus.canceled) {
+        _awaitingBoostProductId = null;
+        onCanceled?.call();
+        return;
+      }
+
+      if (purchase.status == PurchaseStatus.error) {
+        _awaitingBoostProductId = null;
+        onError?.call(
+          purchase.error?.message ?? 'Boost purchase failed',
+        );
+        return;
+      }
+
+      if (purchase.status != PurchaseStatus.purchased &&
+          purchase.status != PurchaseStatus.restored) {
+        return;
+      }
+
+      if (!shouldActivateFromPurchase(
+        purchase,
+        awaitingUserPurchase: awaitingUserPurchase,
+      )) {
+        return;
+      }
+
+      await _boostService.activateBoost(
+        userId: userId,
+        productId: purchase.productID,
+      );
+
+      if (purchase.pendingCompletePurchase) {
+        await _iap.completePurchase(purchase);
+      }
+      _awaitingBoostProductId = null;
+      onActivated();
+    } on Object catch (e, st) {
+      log(
+        'ProfileBoostPurchaseService: boost purchase handling failed: $e',
+        stackTrace: st,
+      );
+      _awaitingBoostProductId = null;
+      onError?.call('Could not activate boost. Please try again.');
+    }
+  }
+
+  /// Test-only: mark an in-flight boost buy (mirrors [buyBoost]).
+  @visibleForTesting
+  void debugSetAwaitingBoostProductId(String? productId) {
+    _awaitingBoostProductId = productId;
+  }
+
   /// Listens for a completed boost purchase and activates boost for [userId].
+  ///
+  /// [onCanceled] and [onError] are only invoked for boost product IDs so
+  /// Premium/other IAP events do not clear the boost CTA spinner.
   StreamSubscription<List<PurchaseDetails>> listenForBoostActivation({
     required String userId,
     required void Function() onActivated,
+    void Function()? onCanceled,
     void Function(String message)? onError,
   }) {
     return _iap.purchaseStream.listen((purchases) async {
       for (final purchase in purchases) {
-        if (purchase.status == PurchaseStatus.purchased ||
-            purchase.status == PurchaseStatus.restored) {
-          final boostIds = await fetchBoostProductIds();
-          if (!boostIds.contains(purchase.productID)) continue;
-
-          if (!shouldActivateFromPurchase(purchase)) {
-            continue;
-          }
-
-          await _boostService.activateBoost(
-            userId: userId,
-            productId: purchase.productID,
-          );
-
-          if (purchase.pendingCompletePurchase) {
-            await _iap.completePurchase(purchase);
-          }
-          onActivated();
-        } else if (purchase.status == PurchaseStatus.error) {
-          onError?.call(
-            purchase.error?.message ?? 'Boost purchase failed',
-          );
-        }
+        await handlePurchaseUpdate(
+          purchase: purchase,
+          userId: userId,
+          onActivated: onActivated,
+          onCanceled: onCanceled,
+          onError: onError,
+        );
       }
     });
   }

--- a/lib/services/profile_boost_purchase_service.dart
+++ b/lib/services/profile_boost_purchase_service.dart
@@ -139,10 +139,26 @@ class ProfileBoostPurchaseService {
   /// Whether the platform billing client is reachable.
   Future<bool> isStoreAvailable() => _iap.isAvailable();
 
+  /// Clears the in-flight buy marker so later restore replays cannot activate.
+  void clearAwaitingBoostPurchase() {
+    _awaitingBoostProductId = null;
+  }
+
   Future<void> buyBoost(ProductDetails product) async {
     _awaitingBoostProductId = product.id;
-    final param = PurchaseParam(productDetails: product);
-    await _iap.buyConsumable(purchaseParam: param);
+    try {
+      final param = PurchaseParam(productDetails: product);
+      final bool started = await _iap.buyConsumable(purchaseParam: param);
+      if (!started) {
+        clearAwaitingBoostPurchase();
+        throw StateError(
+          'Purchase could not be started. Wait a moment and try again.',
+        );
+      }
+    } on Object {
+      clearAwaitingBoostPurchase();
+      rethrow;
+    }
   }
 
   /// Whether a store event should grant a new boost window.

--- a/test/services/profile_boost_purchase_service_test.dart
+++ b/test/services/profile_boost_purchase_service_test.dart
@@ -274,4 +274,87 @@ void main() {
       );
     });
   });
+
+  group('buyBoost awaiting marker', () {
+    late _MockBoostService boostService;
+    late _MockIap iap;
+    late ProfileBoostPurchaseService service;
+
+    ProductDetails product() => ProductDetails(
+          id: boostId,
+          title: 'Boost',
+          description: '1 hour',
+          price: '\$4.99',
+          rawPrice: 4.99,
+          currencyCode: 'USD',
+        );
+
+    setUpAll(() {
+      registerFallbackValue(PurchaseParam(productDetails: product()));
+      registerFallbackValue(details(status: PurchaseStatus.purchased));
+    });
+
+    setUp(() {
+      boostService = _MockBoostService();
+      iap = _MockIap();
+      service = ProfileBoostPurchaseService(
+        iap: iap,
+        boostService: boostService,
+        firestore: _MockFirestore(),
+        boostProductIds: () async => [boostId],
+      );
+      when(
+        () => boostService.activateBoost(
+          userId: any(named: 'userId'),
+          productId: any(named: 'productId'),
+        ),
+      ).thenAnswer((_) async {});
+    });
+
+    test('clears awaiting marker when buyConsumable returns false', () async {
+      when(
+        () => iap.buyConsumable(purchaseParam: any(named: 'purchaseParam')),
+      ).thenAnswer((_) async => false);
+
+      await expectLater(service.buyBoost(product()), throwsStateError);
+
+      var activated = false;
+      await service.handlePurchaseUpdate(
+        purchase: details(status: PurchaseStatus.restored),
+        userId: 'user-1',
+        onActivated: () => activated = true,
+      );
+      expect(activated, isFalse);
+    });
+
+    test('clears awaiting marker when buyConsumable throws', () async {
+      when(
+        () => iap.buyConsumable(purchaseParam: any(named: 'purchaseParam')),
+      ).thenThrow(Exception('store unavailable'));
+
+      await expectLater(service.buyBoost(product()), throwsException);
+
+      var activated = false;
+      await service.handlePurchaseUpdate(
+        purchase: details(status: PurchaseStatus.restored),
+        userId: 'user-1',
+        onActivated: () => activated = true,
+      );
+      expect(activated, isFalse);
+    });
+
+    test('clearAwaitingBoostPurchase blocks later restored activation',
+        () async {
+      service.debugSetAwaitingBoostProductId(boostId);
+      service.clearAwaitingBoostPurchase();
+
+      var activated = false;
+      await service.handlePurchaseUpdate(
+        purchase: details(status: PurchaseStatus.restored),
+        userId: 'user-1',
+        onActivated: () => activated = true,
+      );
+      expect(activated, isFalse);
+    });
+  });
 }

--- a/test/services/profile_boost_purchase_service_test.dart
+++ b/test/services/profile_boost_purchase_service_test.dart
@@ -1,14 +1,27 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:in_app_purchase/in_app_purchase.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:naijasingles/services/profile_boost_purchase_service.dart';
+import 'package:naijasingles/services/profile_boost_service.dart';
+
+class _MockBoostService extends Mock implements ProfileBoostService {}
+
+class _MockIap extends Mock implements InAppPurchase {}
+
+class _MockFirestore extends Mock implements FirebaseFirestore {}
 
 void main() {
+  const boostId = 'com.afropeep.boost.1h';
+
   PurchaseDetails details({
     required PurchaseStatus status,
+    String productId = boostId,
     bool pendingComplete = false,
   }) {
     return PurchaseDetails(
-      productID: 'com.afropeep.boost.1h',
+      productID: productId,
       purchaseID: 'test',
       verificationData: PurchaseVerificationData(
         localVerificationData: '',
@@ -39,6 +52,16 @@ void main() {
       );
     });
 
+    test('activates restored while user buy is in flight', () {
+      expect(
+        ProfileBoostPurchaseService.shouldActivateFromPurchase(
+          details(status: PurchaseStatus.restored),
+          awaitingUserPurchase: true,
+        ),
+        isTrue,
+      );
+    });
+
     test('activates unfinished restored that still need completePurchase', () {
       expect(
         ProfileBoostPurchaseService.shouldActivateFromPurchase(
@@ -48,6 +71,206 @@ void main() {
           ),
         ),
         isTrue,
+      );
+    });
+  });
+
+  group('resolveBoostProductId', () {
+    test('falls back to legacy id when iosProductId is empty', () {
+      expect(
+        ProfileBoostPurchaseService.resolveBoostProductId(
+          {
+            'id': boostId,
+            'iosProductId': '',
+            'androidProductId': '',
+          },
+          platform: TargetPlatform.iOS,
+        ),
+        boostId,
+      );
+    });
+
+    test('prefers non-empty iosProductId over legacy id', () {
+      expect(
+        ProfileBoostPurchaseService.resolveBoostProductId(
+          {
+            'id': 'legacy.boost',
+            'iosProductId': boostId,
+          },
+          platform: TargetPlatform.iOS,
+        ),
+        boostId,
+      );
+    });
+
+    test('falls back to legacy id when androidProductId is empty', () {
+      expect(
+        ProfileBoostPurchaseService.resolveBoostProductId(
+          {
+            'id': boostId,
+            'androidProductId': '   ',
+          },
+          platform: TargetPlatform.android,
+        ),
+        boostId,
+      );
+    });
+
+    test('reads storeIds.ios when present', () {
+      expect(
+        ProfileBoostPurchaseService.resolveBoostProductId(
+          {
+            'id': 'legacy.boost',
+            'iosProductId': '',
+            'storeIds': {'ios': boostId},
+          },
+          platform: TargetPlatform.iOS,
+        ),
+        boostId,
+      );
+    });
+  });
+
+  group('handlePurchaseUpdate', () {
+    late _MockBoostService boostService;
+    late _MockIap iap;
+    late ProfileBoostPurchaseService service;
+
+    setUp(() {
+      boostService = _MockBoostService();
+      iap = _MockIap();
+      service = ProfileBoostPurchaseService(
+        iap: iap,
+        boostService: boostService,
+        firestore: _MockFirestore(),
+        boostProductIds: () async => [boostId],
+      );
+      when(
+        () => boostService.activateBoost(
+          userId: any(named: 'userId'),
+          productId: any(named: 'productId'),
+        ),
+      ).thenAnswer((_) async {});
+      when(() => iap.completePurchase(any())).thenAnswer((_) async {});
+    });
+
+    setUpAll(() {
+      registerFallbackValue(details(status: PurchaseStatus.purchased));
+    });
+
+    test('canceled boost clears purchasing via onCanceled', () async {
+      var canceled = false;
+      var activated = false;
+      var errored = false;
+
+      await service.handlePurchaseUpdate(
+        purchase: details(status: PurchaseStatus.canceled),
+        userId: 'user-1',
+        onActivated: () => activated = true,
+        onCanceled: () => canceled = true,
+        onError: (_) => errored = true,
+      );
+
+      expect(canceled, isTrue);
+      expect(activated, isFalse);
+      expect(errored, isFalse);
+      verifyNever(
+        () => boostService.activateBoost(
+          userId: any(named: 'userId'),
+          productId: any(named: 'productId'),
+        ),
+      );
+    });
+
+    test('ignores canceled non-boost products', () async {
+      var canceled = false;
+
+      await service.handlePurchaseUpdate(
+        purchase: details(
+          status: PurchaseStatus.canceled,
+          productId: 'com.afropeep.premium.monthly',
+        ),
+        userId: 'user-1',
+        onActivated: () {},
+        onCanceled: () => canceled = true,
+      );
+
+      expect(canceled, isFalse);
+    });
+
+    test('activation failure reports onError instead of hanging', () async {
+      when(
+        () => boostService.activateBoost(
+          userId: any(named: 'userId'),
+          productId: any(named: 'productId'),
+        ),
+      ).thenThrow(Exception('permission-denied'));
+
+      String? error;
+      await service.handlePurchaseUpdate(
+        purchase: details(status: PurchaseStatus.purchased),
+        userId: 'user-1',
+        onActivated: () {},
+        onError: (message) => error = message,
+      );
+
+      expect(error, 'Could not activate boost. Please try again.');
+    });
+
+    test('successful purchase activates boost', () async {
+      var activated = false;
+
+      await service.handlePurchaseUpdate(
+        purchase: details(status: PurchaseStatus.purchased),
+        userId: 'user-1',
+        onActivated: () => activated = true,
+      );
+
+      expect(activated, isTrue);
+      verify(
+        () => boostService.activateBoost(
+          userId: 'user-1',
+          productId: boostId,
+        ),
+      ).called(1);
+    });
+
+    test('in-flight buy activates restored with pendingComplete false',
+        () async {
+      var activated = false;
+      service.debugSetAwaitingBoostProductId(boostId);
+
+      await service.handlePurchaseUpdate(
+        purchase: details(status: PurchaseStatus.restored),
+        userId: 'user-1',
+        onActivated: () => activated = true,
+      );
+
+      expect(activated, isTrue);
+      verify(
+        () => boostService.activateBoost(
+          userId: 'user-1',
+          productId: boostId,
+        ),
+      ).called(1);
+    });
+
+    test('cold-start restored without in-flight buy does not activate',
+        () async {
+      var activated = false;
+
+      await service.handlePurchaseUpdate(
+        purchase: details(status: PurchaseStatus.restored),
+        userId: 'user-1',
+        onActivated: () => activated = true,
+      );
+
+      expect(activated, isFalse);
+      verifyNever(
+        () => boostService.activateBoost(
+          userId: any(named: 'userId'),
+          productId: any(named: 'productId'),
+        ),
       );
     });
   });


### PR DESCRIPTION
## Summary
- Fix endless Boost spinner / no activation when StoreKit returns `restored` + `pendingComplete=false` after `buyConsumable` by activating only while an in-flight `buyBoost` is pending.
- Harden product ID resolution so empty `iosProductId`/`androidProductId` fall back to legacy `id`, and clear the CTA spinner on cancel/error/timeout with clearer store/network messaging.
- Add regression tests for in-flight restored activation vs cold-start restore skip.

## Test plan
- [ ] Hot restart → Profile → tap Boost → complete/allow sheet → see “Profile boost is active!” and countdown
- [ ] Relaunch app without buying → restored replay must not grant a fresh boost hour
- [ ] Dismiss StoreKit sheet → spinner clears and Boost button returns
- [ ] `flutter test test/services/profile_boost_purchase_service_test.dart`


Made with [Cursor](https://cursor.com)