### PR TITLE
fix(boost): keep in-flight marker after UI purchase timeout

### DIFF
--- a/lib/features/profile/widgets/profile_boost_banner.dart
+++ b/lib/features/profile/widgets/profile_boost_banner.dart
@@ -48,6 +48,9 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
   bool _loading = true;
   bool _purchasing = false;
 
+  /// True after the UI spinner times out while StoreKit may still complete.
+  bool _waitingOnStore = false;
+
   @override
   void initState() {
     super.initState();
@@ -85,16 +88,23 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
     // Do not clear the in-flight StoreKit marker here: the purchase sheet may
     // still complete after the UI spinner times out.
     if (!mounted) return;
-    if (_purchasing) {
-      setState(() => _purchasing = false);
-    }
+    setState(() {
+      _purchasing = false;
+      _waitingOnStore = false;
+    });
   }
 
   void _startPurchaseTimeout() {
     _purchaseTimeoutTimer?.cancel();
     _purchaseTimeoutTimer = Timer(_purchaseTimeout, () {
       if (!mounted || !_purchasing) return;
-      _clearPurchasing();
+      _purchaseTimeoutTimer = null;
+      // Unlock the spinner, but keep the Boost CTA locked while the original
+      // in-flight marker is still valid so a failed retry cannot wipe it.
+      setState(() {
+        _purchasing = false;
+        _waitingOnStore = _purchaseService.hasValidAwaitingBoostPurchase;
+      });
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
           content: Text(
@@ -169,7 +179,7 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
 
   Future<void> _purchaseBoost() async {
     final uid = widget.currentUser.id ?? FirebaseAuth.instance.currentUser?.uid;
-    if (uid == null || _purchasing) return;
+    if (uid == null || _purchasing || _waitingOnStore) return;
 
     setState(() => _purchasing = true);
     _startPurchaseTimeout();
@@ -212,7 +222,18 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
       await _purchaseService.buyBoost(products.first);
     } on Object catch (e) {
       if (mounted) {
-        _clearPurchasing();
+        // If a prior in-flight purchase is still pending, keep waiting for it
+        // instead of fully unlocking a retry that could clear that marker.
+        if (_purchaseService.hasValidAwaitingBoostPurchase) {
+          _purchaseTimeoutTimer?.cancel();
+          _purchaseTimeoutTimer = null;
+          setState(() {
+            _purchasing = false;
+            _waitingOnStore = true;
+          });
+        } else {
+          _clearPurchasing();
+        }
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Could not start purchase: $e')),
         );
@@ -358,7 +379,8 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
             )
           else
             FilledButton(
-              onPressed: _purchasing ? null : _purchaseBoost,
+              onPressed:
+                  (_purchasing || _waitingOnStore) ? null : _purchaseBoost,
               style: FilledButton.styleFrom(
                 backgroundColor: AppColors.primaryGreen,
                 foregroundColor: Colors.white,
@@ -379,7 +401,7 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
                       ),
                     )
                   : Text(
-                      'Boost',
+                      _waitingOnStore ? 'Waiting…' : 'Boost',
                       style: GoogleFonts.montserrat(
                         fontSize: 13,
                         fontWeight: FontWeight.w700,

--- a/lib/features/profile/widgets/profile_boost_banner.dart
+++ b/lib/features/profile/widgets/profile_boost_banner.dart
@@ -82,7 +82,8 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
   void _clearPurchasing() {
     _purchaseTimeoutTimer?.cancel();
     _purchaseTimeoutTimer = null;
-    _purchaseService.clearAwaitingBoostPurchase();
+    // Do not clear the in-flight StoreKit marker here: the purchase sheet may
+    // still complete after the UI spinner times out.
     if (!mounted) return;
     if (_purchasing) {
       setState(() => _purchasing = false);
@@ -97,7 +98,7 @@ class _ProfileBoostBannerState extends State<ProfileBoostBanner> {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
           content: Text(
-            'Boost purchase timed out. Please try again.',
+            'Still waiting on the App Store. If you finish the purchase, boost will activate.',
           ),
         ),
       );

--- a/lib/services/profile_boost_purchase_service.dart
+++ b/lib/services/profile_boost_purchase_service.dart
@@ -153,6 +153,13 @@ class ProfileBoostPurchaseService {
     _awaitingBoostStartedAt = null;
   }
 
+  /// True while a [buyBoost] marker is still within [awaitingBoostTtl].
+  bool get hasValidAwaitingBoostPurchase {
+    final String? id = _awaitingBoostProductId;
+    if (id == null) return false;
+    return _isAwaitingPurchaseFor(id);
+  }
+
   bool _isAwaitingPurchaseFor(String productId) {
     final String? id = _awaitingBoostProductId;
     final DateTime? started = _awaitingBoostStartedAt;
@@ -167,19 +174,29 @@ class ProfileBoostPurchaseService {
   }
 
   Future<void> buyBoost(ProductDetails product) async {
-    _awaitingBoostProductId = product.id;
-    _awaitingBoostStartedAt = DateTime.now();
+    // Preserve an existing in-flight marker for this SKU. A retry after the UI
+    // timeout must not wipe it if StoreKit rejects the second buy while the
+    // original sheet/transaction is still pending.
+    final bool alreadyAwaiting = _isAwaitingPurchaseFor(product.id);
+    if (!alreadyAwaiting) {
+      _awaitingBoostProductId = product.id;
+      _awaitingBoostStartedAt = DateTime.now();
+    }
     try {
       final param = PurchaseParam(productDetails: product);
       final bool started = await _iap.buyConsumable(purchaseParam: param);
       if (!started) {
-        clearAwaitingBoostPurchase();
+        if (!alreadyAwaiting) {
+          clearAwaitingBoostPurchase();
+        }
         throw StateError(
           'Purchase could not be started. Wait a moment and try again.',
         );
       }
     } on Object {
-      clearAwaitingBoostPurchase();
+      if (!alreadyAwaiting) {
+        clearAwaitingBoostPurchase();
+      }
       rethrow;
     }
   }

--- a/lib/services/profile_boost_purchase_service.dart
+++ b/lib/services/profile_boost_purchase_service.dart
@@ -32,6 +32,14 @@ class ProfileBoostPurchaseService {
   /// for a user-initiated consumable buy. We only activate those while this is set,
   /// so cold-start restore replays still do not re-grant boost.
   String? _awaitingBoostProductId;
+  DateTime? _awaitingBoostStartedAt;
+
+  /// How long an in-flight buy marker remains valid after [buyBoost].
+  ///
+  /// Kept past the UI spinner timeout so a late StoreKit completion still
+  /// activates; expires eventually so abandoned markers cannot grant forever.
+  @visibleForTesting
+  static const Duration awaitingBoostTtl = Duration(minutes: 15);
 
   static const String _packageTypeBoost = 'boost';
 
@@ -142,10 +150,25 @@ class ProfileBoostPurchaseService {
   /// Clears the in-flight buy marker so later restore replays cannot activate.
   void clearAwaitingBoostPurchase() {
     _awaitingBoostProductId = null;
+    _awaitingBoostStartedAt = null;
+  }
+
+  bool _isAwaitingPurchaseFor(String productId) {
+    final String? id = _awaitingBoostProductId;
+    final DateTime? started = _awaitingBoostStartedAt;
+    if (id == null || id != productId || started == null) {
+      return false;
+    }
+    if (DateTime.now().difference(started) > awaitingBoostTtl) {
+      clearAwaitingBoostPurchase();
+      return false;
+    }
+    return true;
   }
 
   Future<void> buyBoost(ProductDetails product) async {
     _awaitingBoostProductId = product.id;
+    _awaitingBoostStartedAt = DateTime.now();
     try {
       final param = PurchaseParam(productDetails: product);
       final bool started = await _iap.buyConsumable(purchaseParam: param);
@@ -194,18 +217,18 @@ class ProfileBoostPurchaseService {
   }) async {
     try {
       final boostIds = await fetchBoostProductIds();
-      final bool awaitingUserPurchase = _awaitingBoostProductId != null &&
-          _awaitingBoostProductId == purchase.productID;
+      final bool awaitingUserPurchase =
+          _isAwaitingPurchaseFor(purchase.productID);
       if (!boostIds.contains(purchase.productID)) return;
 
       if (purchase.status == PurchaseStatus.canceled) {
-        _awaitingBoostProductId = null;
+        clearAwaitingBoostPurchase();
         onCanceled?.call();
         return;
       }
 
       if (purchase.status == PurchaseStatus.error) {
-        _awaitingBoostProductId = null;
+        clearAwaitingBoostPurchase();
         onError?.call(
           purchase.error?.message ?? 'Boost purchase failed',
         );
@@ -232,22 +255,27 @@ class ProfileBoostPurchaseService {
       if (purchase.pendingCompletePurchase) {
         await _iap.completePurchase(purchase);
       }
-      _awaitingBoostProductId = null;
+      clearAwaitingBoostPurchase();
       onActivated();
     } on Object catch (e, st) {
       log(
         'ProfileBoostPurchaseService: boost purchase handling failed: $e',
         stackTrace: st,
       );
-      _awaitingBoostProductId = null;
+      clearAwaitingBoostPurchase();
       onError?.call('Could not activate boost. Please try again.');
     }
   }
 
   /// Test-only: mark an in-flight boost buy (mirrors [buyBoost]).
   @visibleForTesting
-  void debugSetAwaitingBoostProductId(String? productId) {
+  void debugSetAwaitingBoostProductId(
+    String? productId, {
+    DateTime? startedAt,
+  }) {
     _awaitingBoostProductId = productId;
+    _awaitingBoostStartedAt =
+        productId == null ? null : (startedAt ?? DateTime.now());
   }
 
   /// Listens for a completed boost purchase and activates boost for [userId].

--- a/test/services/profile_boost_purchase_service_test.dart
+++ b/test/services/profile_boost_purchase_service_test.dart
@@ -375,5 +375,29 @@ void main() {
       );
       expect(activated, isFalse);
     });
+
+    test('failed retry preserves existing in-flight marker', () async {
+      service.debugSetAwaitingBoostProductId(boostId);
+      when(
+        () => iap.buyConsumable(purchaseParam: any(named: 'purchaseParam')),
+      ).thenAnswer((_) async => false);
+
+      await expectLater(service.buyBoost(product()), throwsStateError);
+      expect(service.hasValidAwaitingBoostPurchase, isTrue);
+
+      var activated = false;
+      await service.handlePurchaseUpdate(
+        purchase: details(status: PurchaseStatus.restored),
+        userId: 'user-1',
+        onActivated: () => activated = true,
+      );
+      expect(activated, isTrue);
+      verify(
+        () => boostService.activateBoost(
+          userId: 'user-1',
+          productId: boostId,
+        ),
+      ).called(1);
+    });
   });
 }

--- a/test/services/profile_boost_purchase_service_test.dart
+++ b/test/services/profile_boost_purchase_service_test.dart
@@ -356,5 +356,24 @@ void main() {
       );
       expect(activated, isFalse);
     });
+
+    test('expired awaiting marker does not activate restored purchase',
+        () async {
+      service.debugSetAwaitingBoostProductId(
+        boostId,
+        startedAt: DateTime.now().subtract(
+          ProfileBoostPurchaseService.awaitingBoostTtl +
+              const Duration(seconds: 1),
+        ),
+      );
+
+      var activated = false;
+      await service.handlePurchaseUpdate(
+        purchase: details(status: PurchaseStatus.restored),
+        userId: 'user-1',
+        onActivated: () => activated = true,
+      );
+      expect(activated, isFalse);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Addresses Codex P1 on develop→main [#219](https://github.com/tosyno87/naijaSingles/pull/219): UI timeout no longer clears `_awaitingBoostProductId`, so a purchase completed after 90s still activates boost.
- Adds a 15-minute TTL on the in-flight marker so abandoned sessions cannot grant free restores indefinitely.
- Softens the timeout snackbar copy to reflect that a late completion can still succeed.

## Test plan
- [ ] Tap Boost, leave StoreKit sheet open past ~90s → spinner clears, snackbar notes waiting on App Store
- [ ] Complete the sheet after timeout → boost activates and countdown shows
- [ ] Cancel sheet → no activation; cold-start restore still does not re-grant
- [ ] `flutter test test/services/profile_boost_purchase_service_test.dart`


Made with [Cursor](https://cursor.com)