### PR TITLE
fix(discovery): harden Reset filters against failed and in-flight writes

### DIFF
--- a/lib/features/discovery/presentation/screens/discovery_preferences_screen.dart
+++ b/lib/features/discovery/presentation/screens/discovery_preferences_screen.dart
@@ -60,6 +60,9 @@ class _DiscoveryPreferencesScreenState
   bool _showAppliedConfirm = false;
   Timer? _appliedConfirmTimer;
 
+  /// True while a Reset filters write is in flight (distinct from Apply).
+  bool _pendingWriteIsReset = false;
+
   /// Bumps when filters reset so [LookingForConnectionCard] rebuilds its selection.
   int _lookingForCardKey = 0;
 
@@ -232,6 +235,7 @@ class _DiscoveryPreferencesScreenState
       _strictIntent = false;
       _verifiedOnly = false;
       _lookingForCardKey++;
+      _pendingWriteIsReset = true;
     });
     // Strict flags are written as false explicitly to clear any previously
     // saved dealbreakers on the user doc.
@@ -285,6 +289,10 @@ class _DiscoveryPreferencesScreenState
       // Silent no-op (Tinder/Hinge-style) — no dismissible snackbar.
       return;
     }
+    if (context.read<UserfilterBloc>().state is UpdatingUserFilter) {
+      return;
+    }
+    _pendingWriteIsReset = false;
     context.read<UserfilterBloc>().add(
           ChangefilterRequest(details: _buildPayload()),
         );
@@ -353,10 +361,23 @@ class _DiscoveryPreferencesScreenState
               'Filter not applied..'.tr(),
               context,
             );
+            // Reset mutates the shared model before the write finishes. If
+            // persistence fails, roll back so UI/discovery match Firestore.
+            if (_pendingWriteIsReset) {
+              setState(() {
+                _restoreLastSavedValues();
+                _lookingForCardKey++;
+                _pendingWriteIsReset = false;
+              });
+              context.read<SearchUserBloc>().add(
+                    LoadUserEvent(currentUser: widget.currentUser),
+                  );
+            }
           } else if (state is UserFilterUpdated) {
             unawaited(HapticFeedback.lightImpact());
             changeValues.clear();
             _snapshotLastSavedValues();
+            _pendingWriteIsReset = false;
             _appliedConfirmTimer?.cancel();
             setState(() {
               _strictAge = false;
@@ -373,7 +394,10 @@ class _DiscoveryPreferencesScreenState
             });
           }
         },
-        child: PopScope(
+        child: BlocBuilder<UserfilterBloc, UserfilterState>(
+          builder: (BuildContext context, UserfilterState filterState) {
+            final bool filtersBusy = filterState is UpdatingUserFilter;
+            return PopScope(
           canPop: false,
           onPopInvokedWithResult: (bool didPop, Object? result) async {
             if (didPop) return;
@@ -398,7 +422,7 @@ class _DiscoveryPreferencesScreenState
               ),
               actions: [
                 TextButton(
-                  onPressed: _resetFilters,
+                  onPressed: filtersBusy ? null : _resetFilters,
                   child: Text(
                     'Reset filters'.tr(),
                     style: GoogleFonts.montserrat(
@@ -414,7 +438,11 @@ class _DiscoveryPreferencesScreenState
             body: Column(
               children: [
                 Expanded(
-                  child: ListView(
+                  child: AbsorbPointer(
+                    absorbing: filtersBusy,
+                    child: Opacity(
+                      opacity: filtersBusy ? 0.6 : 1,
+                      child: ListView(
                     padding: const EdgeInsets.fromLTRB(
                       AppSpacing.lg,
                       AppSpacing.sm,
@@ -568,6 +596,8 @@ class _DiscoveryPreferencesScreenState
                       const SizedBox(height: 88),
                     ],
                   ),
+                    ),
+                  ),
                 ),
                 Material(
                   elevation: 12,
@@ -579,7 +609,9 @@ class _DiscoveryPreferencesScreenState
                     child: SizedBox(
                       width: double.infinity,
                       child: ElevatedButton(
-                        onPressed: _showAppliedConfirm ? null : _applyFilters,
+                        onPressed: (_showAppliedConfirm || filtersBusy)
+                            ? null
+                            : _applyFilters,
                         style: ElevatedButton.styleFrom(
                           backgroundColor: _showAppliedConfirm
                               ? AppColors.primaryGreen.withValues(alpha: 0.85)
@@ -628,6 +660,8 @@ class _DiscoveryPreferencesScreenState
               ],
             ),
           ),
+        );
+          },
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- Addresses Codex P2 review on [#222](https://github.com/tosyno87/naijaSingles/pull/222): when **Reset filters** persistence fails (e.g. offline), restore the shared `UserModel` to the last-saved snapshot, rebuild the looking-for card, and reload discovery so UI/results match Firestore again.
- While any filter write is in flight (`UpdatingUserFilter`), absorb pointer events on the filter list and disable Reset/Apply so mid-flight edits cannot be cleared or snapshotted by the reset success listener.

## Test plan
- [ ] Open Discovery Filters, change values, tap Reset — UI locks briefly, then defaults save and "Applied" shows.
- [ ] Toggle airplane mode, tap Reset — snackbar appears, controls roll back to previous saved values, leaving without a false "clean" state.
- [ ] With network on, tap Reset and confirm filters stay disabled until the write finishes (no mid-flight edits).
- [ ] Apply a normal intent/distance change still works after these guards.

Made with [Cursor](https://cursor.com)